### PR TITLE
All tests now running. Currently 9 fail.

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,7 +14,7 @@ __version__ = "0.0.0"
 import unittest
 import logging
 
-from .. import api
+from jamf import api
 
 
 class MockResponse:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,7 +18,7 @@ import plistlib
 import unittest
 import datetime as dt
 
-from .. import config
+from jamf import config
 
 # temporary files created with tests
 LOCATION = pathlib.Path(__file__).parent

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -3,7 +3,7 @@
 #pylint: disable=missing-class-docstring, missing-module-docstring, invalid-name
 
 import unittest
-from .. import convert
+from jamf import convert
 
 patchpolicies = '''<?xml version="1.0" encoding="UTF-8"?>
 <patch_available_titles>

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -16,9 +16,9 @@ import shutil
 import pathlib
 import unittest
 
-from .. import package
-from .. import api
-from .. import category
+from jamf import package
+from jamf import api
+from jamf import category
 
 # location for temporary files created with tests
 LOCATION = pathlib.Path(__file__).parent

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -9,7 +9,7 @@ Test the Jamf object classes
 
 import unittest
 
-from .. import records
+from jamf import records
 from . import data
 from .MockAPI import MockAPI, MockAPIError
 


### PR DESCRIPTION
I figured out why `python3 -m unittest discover -v` wasn't working. When we moved tests out of `jamf` and put them on the same level in `python-jamf` the imports tried to import from  a parent that didn't exist.

So all the `from .. import <package>` had to be changed to `from jamf import <package>`

Tomorrow I will see about fixing the 9 tests that error.