### PR TITLE
APIError no longer prints traceback and message is on two lines

### DIFF
--- a/jamf/api.py
+++ b/jamf/api.py
@@ -16,7 +16,7 @@ import html.parser
 import logging
 import logging.handlers
 import pathlib
-from os import path
+from os import path, _exit
 import plistlib
 import subprocess
 import requests
@@ -37,19 +37,11 @@ class Error(Exception):
 class APIError(Error):
     """ Error in our call """
     def __init__(self, response):
-        self.response = response
-        err = parse_html_error(response.text)
+        rsp = response
+        err = parse_html_error(rsp.text)
         self.message = ": ".join(err) or 'failed'
-
-    def __getattr__(self, attr):
-        """
-        missing attributes fallback on response
-        """
-        return getattr(self.response, attr)
-
-    def __str__(self):
-        rsp = self.response
-        return f"{rsp}: {rsp.request.method} - {rsp.url}: {self.message}"
+        print(f"{rsp}: {rsp.request.method} - {rsp.url}: \n{self.message}")
+        _exit(1)
 
 
 class Singleton(type):


### PR DESCRIPTION
APIError no longer prints traceback and message is on two lines for legibility.