### PR TITLE
Changes to fix install of `jamfconfig` into `/usr/local/bin`

### DIFF
--- a/jamf/setconfig.py
+++ b/jamf/setconfig.py
@@ -136,8 +136,12 @@ def setconfig(argv):
         conf.save(config_path=config_path)
 
 
-if __name__ == '__main__':
+def main():
     check_version()
-    fmt = '%(asctime)s: %(levelname)8s: %(name)s - %(funcName)s(): %(message)s'
+    fmt = "%(asctime)s: %(levelname)8s: %(name)s - %(funcName)s(): %(message)s"
     logging.basicConfig(level=logging.INFO, format=fmt)
     setconfig(sys.argv[1:])
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     package_data={'': ['*.json']},
     entry_points={
-        'console_scripts': ['jamfconfig=jamf.setconfig:setconfig']
+        'console_scripts': ['jamfconfig=jamf.setconfig:main']
     },
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Some tiny changes to setup.py and setconfig.py. The install of a small script called `jamfconfig` which calls `setconfig.py` into the right spot when you perform `pip install python-jamf` now works correctly.