### PR TITLE
Rewrote records.py.

### DIFF
--- a/jamf/__init__.py
+++ b/jamf/__init__.py
@@ -11,4 +11,4 @@ from . import package
 from . import convert
 from .records import *
 from .setconfig import setconfig
-__version__ = "0.5.6"
+__version__ = "0.6.0"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="python-jamf",
-    version="0.5.6",
+    version="0.6.0",
     author="The University of Utah",
     author_email="mlib-its-mac@lists.utah.edu",
     description="Python wrapper for Jamf Pro API",


### PR DESCRIPTION
Rewrote records.py. Basically, I made category.py generic and renamed Category to Record and Categories to Records, then I took all of the subclasses from the old records.py and made them work with the new Record and Records.

This breaks jctl so don't merge it until I submit a pull request for jctl, which might not be today...

Here's the details. Renamed Record class to Records (list of jamf records). Created Record class (individual jamf record). Removed LicensedSoftware, RestrictedSoftware classes (the singular name is the same as the plural name and doesn't fit in yet). Turned all subclasses of record and records into singletons. Moved getPlural to Records.refresh() and getSingle to Record.refresh(). Record.init() no longer calls get(). Instead of querying the server in init, the server is queried whenever a record is requested (lazy loading). Same goes for detailed Record data. Removed list_to_dict, list, get, put, post, delete, get_path, set_path, records_by_name, etc. Added Records methods: names, ids, recordWithId, recordWithName, recordsWithRegex, and find. Will add put, post, and delete back when they are updated. Also added RecordsIterator class (from category.py). I also created a ClassicSwagger class and moved all of the swagger code into it because it was getting messy.

Sam had this old example code.

	from jamf.category import Categories
	allcategories = Categories()
	allcategories.names()
	allcategories.ids()
	allcategories.categoryWithName("Utilities")
	allcategories.categoryWithId(141)

	for item in allcategories:
		repr(item)

	category = Categories().find("Utilities")
	repr(category)
	category = Categories().find(141)
	repr(category)

The file category.py is still around so the above code works as is.  But now it works generically too with records.py and changing categoryWithName and categoryWithId to recordWithName and recordWithId.

	from jamf.records import Categories
	allcategories = Categories()
	allcategories.names()
	allcategories.ids()
	allcategories.recordWithName("Utilities")
	allcategories.recordWithId(141)

	for item in allcategories:
		repr(item)

	category = Categories().find("Utilities")
	repr(category)
	category = Categories().find(141)
	repr(category)

And now this works too.

	from jamf.records import Computers
	allcomputers = Computers()
	allcomputers.names()
	allcomputers.ids()
	allcomputers.recordWithName("Utilities")
	allcomputers.recordWithId(141)

	for item in allcomputers:
		repr(item)

	computer = Computers().find("Utilities")
	repr(computer)
	computer = Computers().find(141)
	repr(computer)

And all of the other records work too (except the ones we aren't supporting). In addition, you can get all of the data of a record by running the data method like so.

Computers().find(556).data()

Sam didn't have code for this, so this is all extra. Sam's code had iteration but not sorting. I added sorting of records.

The advantage of this over the old way is that the Computers object is a singleton, and it has an internal list of Computer objects, and those are singletons also. The actual data is lazy loaded. Each computer isn't fetched until data() is called. If the computer "M1" has the id 556, then if I call Computers().find("M1").data() the data wont be fetched again because it's already been fetched (above example). The old way fetched over and over.

Obviously, this regresses jctl because half of the methods jctl needed are still missing. I am aware this should be it's own branch but I don't know how to do that yet with github and pull requests and if this were past 1.0 I'd probably make myself do it, but it's still 0.x and nobody is using it besides me to the best of my knowledge.