### PR TITLE
Consider using Python Black for automatic formatting consistency

### DIFF
--- a/jamf/api.py
+++ b/jamf/api.py
@@ -6,10 +6,10 @@ JSS API
 Modifications by Tony Williams (tonyw@honestpuck.com) (ARW)
 """
 
-__author__ = 'Sam Forester'
-__email__ = 'sam.forester@utah.edu'
-__copyright__ = 'Copyright (c) 2020 University of Utah, Marriott Library'
-__license__ = 'MIT'
+__author__ = "Sam Forester"
+__email__ = "sam.forester@utah.edu"
+__copyright__ = "Copyright (c) 2020 University of Utah, Marriott Library"
+__license__ = "MIT"
 __version__ = "0.4.7"
 
 import html.parser
@@ -27,20 +27,24 @@ from . import config
 
 LOGLEVEL = logging.INFO
 
-#pylint: disable=unnecessary-pass
+# pylint: disable=unnecessary-pass
 class Error(Exception):
-    """ just passing through """
+    """just passing through"""
+
     pass
 
 
-#pylint: disable=super-init-not-called
+# pylint: disable=super-init-not-called
 class APIError(Error):
-    """ Error in our call """
+    """Error in our call"""
+
     def __init__(self, response):
         self.response = response
         err = parse_html_error(response.text)
-        self.message = ": ".join(err) or 'failed'
-        print(f"{response}: {response.request.method} - {response.url}: \n{self.message}")
+        self.message = ": ".join(err) or "failed"
+        print(
+            f"{response}: {response.request.method} - {response.url}: \n{self.message}"
+        )
 
     def __getattr__(self, attr):
         """
@@ -54,8 +58,10 @@ class APIError(Error):
 
 
 class Singleton(type):
-    """ allows us to share a single object """
+    """allows us to share a single object"""
+
     _instances = {}
+
     def __call__(cls, *a, **kw):
         if cls not in cls._instances:
             cls._instances[cls] = super(Singleton, cls).__call__(*a, **kw)
@@ -66,14 +72,12 @@ class API(metaclass=Singleton):
     """
     Class for making api calls to JSS
     """
+
     session = False
 
-    def __init__(self,
-                 config_path=None,
-                 hostname=None,
-                 username=None,
-                 password=None,
-                 prompt=True):
+    def __init__(
+        self, config_path=None, hostname=None, username=None, password=None, prompt=True
+    ):
         """
         Create requests.Session with JSS address and authentication
 
@@ -88,11 +92,13 @@ class API(metaclass=Singleton):
         self.log = logging.getLogger(f"{__name__}.API")
         self.log.setLevel(LOGLEVEL)
         # Load Prefs and Init session
-        conf = config.Config(config_path=config_path,
-                             hostname=hostname,
-                             username=username,
-                             password=password,
-                             prompt=prompt)
+        conf = config.Config(
+            config_path=config_path,
+            hostname=hostname,
+            username=username,
+            password=password,
+            prompt=prompt,
+        )
         hostname = hostname or conf.hostname
         username = username or conf.username
         password = password or conf.password
@@ -100,13 +106,13 @@ class API(metaclass=Singleton):
         if not hostname and not username and not password:
             print("No jamf hostname or credentials could be found.")
             exit(1)
-        if hostname[-1] == '/':
+        if hostname[-1] == "/":
             self.url = f"{hostname}JSSResource"
         else:
             self.url = f"{hostname}/JSSResource"
         self.session = requests.Session()
         self.session.auth = (username, password)
-        self.session.headers.update({'Accept': 'application/xml'})
+        self.session.headers.update({"Accept": "application/xml"})
 
     def get(self, endpoint, raw=False):
         """
@@ -229,7 +235,8 @@ class API(metaclass=Singleton):
             self.log.debug("closing session")
             self.session.close()
 
-#pylint: disable=too-few-public-methods, abstract-method
+
+# pylint: disable=too-few-public-methods, abstract-method
 class _DummyTag:
     """
     Minimal mock implementation of bs4.element.Tag (only has text attribute)
@@ -238,6 +245,7 @@ class _DummyTag:
     >>> eg.text
     'some text'
     """
+
     def __init__(self, text):
         self.text = text
 
@@ -250,6 +258,7 @@ class JSSErrorParser(html.parser.HTMLParser):
     ['Unauthorized', 'The request requires user authentication',
      'You can get technical details here. {...}']
     """
+
     def __init__(self, _html):
         super().__init__()
         self._data = {}
@@ -265,7 +274,7 @@ class JSSErrorParser(html.parser.HTMLParser):
         """
         return self._data.get(tag, [])
 
-    #pylint: disable=attribute-defined-outside-init
+    # pylint: disable=attribute-defined-outside-init
     def handle_data(self, data):
         """
         override HTMLParser().handle_data()
@@ -284,6 +293,7 @@ class JSSErrorParser(html.parser.HTMLParser):
         self._data.setdefault(tag, [])
         self._data[tag].append(self._dummytag)
 
+
 def parse_html_error(error):
     """
     Get meaningful error information from JSS Error response HTML
@@ -298,4 +308,4 @@ def parse_html_error(error):
     #        'You can get technical details here. (...)']
     # NOTE: get first two <p> tags from HTML error response
     #       3rd <p> is always 'You can get technical details here...'
-    return [t.text for t in soup.find_all('p')][0:2]
+    return [t.text for t in soup.find_all("p")][0:2]

--- a/jamf/config.py
+++ b/jamf/config.py
@@ -4,10 +4,10 @@
 Configuration for jamfutil
 """
 
-__author__ = 'Sam Forester'
-__email__ = 'sam.forester@utah.edu'
-__copyright__ = 'Copyright (c) 2020 University of Utah, Marriott Library'
-__license__ = 'MIT'
+__author__ = "Sam Forester"
+__email__ = "sam.forester@utah.edu"
+__copyright__ = "Copyright (c) 2020 University of Utah, Marriott Library"
+__license__ = "MIT"
 __version__ = "1.2.4"
 
 import getpass
@@ -15,21 +15,24 @@ import logging
 import plistlib
 import keyring
 from os import path, remove
-LINUX_PREFS_TILDA = '~/.edu.utah.mlib.jamfutil.plist'
-MACOS_PREFS_TILDA = '~/Library/Preferences/edu.utah.mlib.jamfutil.plist'
-AUTOPKG_PREFS_TILDA = '~/Library/Preferences/com.github.autopkg.plist'
-JAMF_PREFS = '/Library/Preferences/com.jamfsoftware.jamf.plist'
+
+LINUX_PREFS_TILDA = "~/.edu.utah.mlib.jamfutil.plist"
+MACOS_PREFS_TILDA = "~/Library/Preferences/edu.utah.mlib.jamfutil.plist"
+AUTOPKG_PREFS_TILDA = "~/Library/Preferences/com.github.autopkg.plist"
+JAMF_PREFS = "/Library/Preferences/com.jamfsoftware.jamf.plist"
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 
 class Config:
-    def __init__(self,
-                 config_path=None,
-                 hostname=None,
-                 username=None,
-                 password=None,
-                 prompt=False,
-                 explain=False):
+    def __init__(
+        self,
+        config_path=None,
+        hostname=None,
+        username=None,
+        password=None,
+        prompt=False,
+        explain=False,
+    ):
         self.log = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
         self.prompt = prompt
         self.hostname = hostname
@@ -42,39 +45,39 @@ class Config:
                 autopkg_prefs = path.expanduser(AUTOPKG_PREFS_TILDA)
                 if path.exists(macos_prefs):
                     if explain:
-                        print("Using macos: "+macos_prefs)
+                        print("Using macos: " + macos_prefs)
                     config_path = macos_prefs
                 elif path.exists(linux_prefs):
                     if explain:
-                        print("Using linux: "+linux_prefs)
+                        print("Using linux: " + linux_prefs)
                     config_path = linux_prefs
                 elif path.exists(autopkg_prefs):
                     if explain:
-                        print("Using autopkg: "+autopkg_prefs)
+                        print("Using autopkg: " + autopkg_prefs)
                     config_path = autopkg_prefs
                 elif path.exists(JAMF_PREFS):
                     if explain:
-                        print("Using jamf: "+JAMF_PREFS)
+                        print("Using jamf: " + JAMF_PREFS)
                     config_path = JAMF_PREFS
                 else:
                     if explain:
-                        print("Using "+macos_prefs+" but it doesn't exist yet.")
+                        print("Using " + macos_prefs + " but it doesn't exist yet.")
                     config_path = macos_prefs
             elif explain:
-                    print("Using "+config_path+" because you said so.")
+                print("Using " + config_path + " because you said so.")
 
-            if config_path[0] == '~':
+            if config_path[0] == "~":
                 config_path = path.expanduser(config_path)
                 if explain:
-                    print("Expanding the path. Using "+config_path)
+                    print("Expanding the path. Using " + config_path)
 
             if not self.hostname and not self.username and not self.password:
                 if path.exists(config_path):
-                    fptr = open(config_path, 'rb')
+                    fptr = open(config_path, "rb")
                     prefs = plistlib.load(fptr)
                     fptr.close()
-                    if 'JSSHostname' in prefs:
-                        if 'Credentials' in prefs:
+                    if "JSSHostname" in prefs:
+                        if "Credentials" in prefs:
                             cmessage = f"""
 ATTENTION
 To improve security with storing credentials used with the jctl tool, we have
@@ -87,15 +90,16 @@ Please delete the the configuration at {config_path} and recreate it using
 the "./jamf/setconfig.py" script.
 """
                             raise Exception(cmessage)
-                        self.hostname = prefs['JSSHostname']
-                        self.username = prefs['Username']
-                        self.password = keyring.get_password(self.hostname,
-                                                             self.username)
-                    elif 'JSS_URL' in prefs:
+                        self.hostname = prefs["JSSHostname"]
+                        self.username = prefs["Username"]
+                        self.password = keyring.get_password(
+                            self.hostname, self.username
+                        )
+                    elif "JSS_URL" in prefs:
                         self.hostname = prefs["JSS_URL"]
                         self.username = prefs["API_USERNAME"]
                         self.password = prefs["API_PASSWORD"]
-                    elif 'jss_url' in prefs:
+                    elif "jss_url" in prefs:
                         self.hostname = prefs["jss_url"]
                         # No auth in that file
                 else:
@@ -112,16 +116,13 @@ the "./jamf/setconfig.py" script.
             if not self.password:
                 self.password = getpass.getpass()
         elif not self.hostname and not self.username and not self.password:
-            raise Exception('No jamf config file could be found and prompt is off.')
+            raise Exception("No jamf config file could be found and prompt is off.")
 
     def save(self, config_path=None):
         keyring.set_password(self.hostname, self.username, self.password)
-        data = {
-            'JSSHostname': self.hostname,
-            'Username': self.username
-        }
+        data = {"JSSHostname": self.hostname, "Username": self.username}
         self.log.info(f"saving: {config_path}")
-        fptr = open(config_path, 'wb')
+        fptr = open(config_path, "wb")
         plistlib.dump(data, fptr)
         fptr.close()
 
@@ -131,4 +132,4 @@ the "./jamf/setconfig.py" script.
 
 
 def prompt_hostname():
-    return input('Hostname (don\'t forget https:// and :8443): ')
+    return input("Hostname (don't forget https:// and :8443): ")

--- a/jamf/convert.py
+++ b/jamf/convert.py
@@ -4,10 +4,10 @@
 XML and JSON data conversion functions
 """
 
-__author__ = 'Sam Forester'
-__email__ = 'sam.forester@utah.edu'
-__copyright__ = 'Copyright (c) 2019 University of Utah, Marriott Library'
-__license__ = 'MIT'
+__author__ = "Sam Forester"
+__email__ = "sam.forester@utah.edu"
+__copyright__ = "Copyright (c) 2019 University of Utah, Marriott Library"
+__license__ = "MIT"
 __version__ = "0.2.2"
 
 from xml.etree import cElementTree as ElementTree
@@ -16,7 +16,8 @@ from collections import defaultdict
 
 
 class Error(Exception):
-    """ just passing through """
+    """just passing through"""
+
     pass
 
 
@@ -35,7 +36,7 @@ def etree_to_dict(elem):
                 defd[key].append(val)
         result = {
             elem.tag: {
-                key:val[0] if len(val) == 1 else val for key, val in defd.items()
+                key: val[0] if len(val) == 1 else val for key, val in defd.items()
             }
         }
     elif elem.text:
@@ -49,7 +50,7 @@ def dict_to_xml(data):
     :returns:  xml string
     """
     if isinstance(data, dict):
-        xml_str = ''
+        xml_str = ""
         for key, value in data.items():
             if value is None:
                 xml_str += f"<{key}/>"

--- a/jamf/package.py
+++ b/jamf/package.py
@@ -4,10 +4,10 @@
 JAMF Packages
 """
 
-__author__ = 'Sam Forester'
-__email__ = 'sam.forester@utah.edu'
-__copyright__ = 'Copyright (c) 2020 University of Utah, Marriott Library'
-__license__ = 'MIT'
+__author__ = "Sam Forester"
+__email__ = "sam.forester@utah.edu"
+__copyright__ = "Copyright (c) 2020 University of Utah, Marriott Library"
+__license__ = "MIT"
 __version__ = "1.1.3"
 
 # import re
@@ -26,9 +26,9 @@ from .records import Categories
 from . import config
 
 # GLOBALS
-TMPDIR = os.environ.get('TMPDIR', '/tmp')
-TMPDIR = pathlib.Path(TMPDIR).resolve() / 'edu.utah.mlib.packages'
-VERSIONKEY = 'edu.utah.mlib.jctl:LSMinimumSystemVersion'
+TMPDIR = os.environ.get("TMPDIR", "/tmp")
+TMPDIR = pathlib.Path(TMPDIR).resolve() / "edu.utah.mlib.packages"
+VERSIONKEY = "edu.utah.mlib.jctl:LSMinimumSystemVersion"
 # RECEIPTS = pathlib.Path('/var/db/receipts').resolve()
 # logger = logging.getLogger(__name__)
 
@@ -45,12 +45,13 @@ class Manager:
     """
     Package Manager
     """
+
     def __init__(self, api, admin):
         self.log = logging.getLogger(f"{__name__}.Manager")
         self.admin = admin
         # self.repos = repos
         self.api = api
-        self._packages = {'jss': []}
+        self._packages = {"jss": []}
         # self._uploaded = {}
 
     def find_name(self, name):
@@ -59,7 +60,7 @@ class Manager:
         :returns Package:
         """
         raise NotImplementedError()
-        #if not name and not jssid and not path:
+        # if not name and not jssid and not path:
         #    raise ValueError("must specify name, path, or ID")
 
     def _find(self, key, value):
@@ -75,17 +76,17 @@ class Manager:
         :param repo <Repo>:  package.Repo object
         :returns <list>:     list of new packages
         """
-        names = [r['name'] for r in self.jss_packages(**kwargs)]
+        names = [r["name"] for r in self.jss_packages(**kwargs)]
         return [pkg for pkg in repo.packages if pkg.name not in names]
 
     def jss_packages(self, refresh=False):
         """
         get all packages from JSS
         """
-        if refresh or not self._packages['jss']:
-            pkgs = self.api.get('packages')['packages']['package']
-            self._packages['jss'] = pkgs
-        return self._packages['jss']
+        if refresh or not self._packages["jss"]:
+            pkgs = self.api.get("packages")["packages"]["package"]
+            self._packages["jss"] = pkgs
+        return self._packages["jss"]
 
     def archive(self, pkg, path=None):
         """
@@ -119,26 +120,25 @@ class Manager:
 
 
 class BasePackage:
-
     def __init__(self, name):
         self.name = name
-        self.info = {'pkginfo': {'install-location': None,
-                                 'identifier': None,
-                                 'version': None},
-                     'name': name,
-                     'path': None,
-                     'contents': []}
+        self.info = {
+            "pkginfo": {"install-location": None, "identifier": None, "version": None},
+            "name": name,
+            "path": None,
+            "contents": [],
+        }
 
     @property
     def identifier(self):
-        _id = self.info['pkginfo']['identifier']
+        _id = self.info["pkginfo"]["identifier"]
         if not _id:
             raise ValueError("unable to determine identifier")
         return _id
 
     @property
     def version(self):
-        _version = self.info['pkginfo']['version']
+        _version = self.info["pkginfo"]["version"]
         if not _version:
             # attempt to figure out the version from the name?
             raise ValueError("unable to determine version")
@@ -161,8 +161,11 @@ class BasePackage:
             if not self.identifier == x.identifier:
                 raise ValueError(f"{self.identifer} != {x.identifier}")
             # if versions are identical, check the name
-            return (self.version < x.version
-                   if not self.version == x.version else self.name < x.name)
+            return (
+                self.version < x.version
+                if not self.version == x.version
+                else self.name < x.name
+            )
         else:
             raise TypeError(f"unable to compare {x!r}: {type(x)}")
 
@@ -174,8 +177,11 @@ class BasePackage:
             if not self.identifier == x.identifier:
                 raise ValueError(f"{self.identifer} != {x.identifier}")
             # if versions are identical, check the name
-            return (self.version > x.version
-                   if not self.version == x.version else self.name > x.name)
+            return (
+                self.version > x.version
+                if not self.version == x.version
+                else self.name > x.name
+            )
         else:
             raise TypeError(f"unable to compare {x!r}: {type(x)}")
 
@@ -196,26 +202,24 @@ class BasePackage:
 
 
 class App:
-
     def __init__(self, data):
-        self.identifier = data['CFBundleIdentifier']
-        self.version = data['CFBundleShortVersionString']
-        self.bundle_version = data['CFBundleVersion']
-        self.minimum_os = data.get('LSMinimumSystemVersion')
+        self.identifier = data["CFBundleIdentifier"]
+        self.version = data["CFBundleShortVersionString"]
+        self.bundle_version = data["CFBundleVersion"]
+        self.minimum_os = data.get("LSMinimumSystemVersion")
 
     def values(self):
-        keys = ('identifier', 'version', 'bundle_version', 'minimum_os')
+        keys = ("identifier", "version", "bundle_version", "minimum_os")
         return tuple(getattr(self, k) for k in keys)
 
     def items(self):
-        return {k:v for k, v in self.__dict__.items() if not k.startswith('_')}
+        return {k: v for k, v in self.__dict__.items() if not k.startswith("_")}
 
     def __iter__(self):
         yield self.values()
 
 
 class Package:
-
     def __init__(self, path):
         self.log = logging.getLogger(f"{__name__}.Package")
         self.path = pathlib.Path(path)
@@ -272,7 +276,7 @@ class Package:
         :returns: package version
         """
         if not self._version:
-            v = self.info['pkginfo']['version']
+            v = self.info["pkginfo"]["version"]
             if v:
                 try:
                     # NOTE: StrictVersion(None) and StrictVersion('')
@@ -290,14 +294,14 @@ class Package:
         """
         :returns: package bundle identifier
         """
-        return self.info['pkginfo']['identifier']
+        return self.info["pkginfo"]["identifier"]
 
     @property
     def location(self):
         """
         :returns: package install-location
         """
-        return self.info['pkginfo']['install-location']
+        return self.info["pkginfo"]["install-location"]
 
     @property
     def apps(self):
@@ -305,9 +309,9 @@ class Package:
         :returns: list of apps that will be installed by the package
         """
         if not self._apps:
-            for bundle in self.info['contents']:
-                if bundle['name'].endswith('.app'):
-                    os = {'LSMinimumSystemVersion': str(self.minimum_os)}
+            for bundle in self.info["contents"]:
+                if bundle["name"].endswith(".app"):
+                    os = {"LSMinimumSystemVersion": str(self.minimum_os)}
                     bundle.update(os)
                     self._apps.append(bundle)
         return self._apps
@@ -320,7 +324,7 @@ class Package:
         if not self._min_os_ver:
             # check for our metadata flag
             try:
-                _version = xattr('-p', VERSIONKEY, self.path)
+                _version = xattr("-p", VERSIONKEY, self.path)
             except subprocess.CalledProcessError:
                 pass
             else:
@@ -329,30 +333,30 @@ class Package:
                     self._min_os_ver = StrictVersion(_version)
                 else:
                     # remove empty metadata key
-                    xattr('-d', VERSIONKEY, self.path)
+                    xattr("-d", VERSIONKEY, self.path)
         # if there's no metadata, we have to check the plist in the payload
         if not self._min_os_ver:
             # missing metadata key
             expanded = self.expand()
-            _pkg = package_information(path=expanded/'PackageInfo')
+            _pkg = package_information(path=expanded / "PackageInfo")
             versions = []
-            for bundle in _pkg['bundles']:
-                payload = expanded / 'Payload'
+            for bundle in _pkg["bundles"]:
+                payload = expanded / "Payload"
                 # very expensive for large packages (especially over network)
                 try:
-                    plist = extract_info_plist(payload, bundle['path'])
+                    plist = extract_info_plist(payload, bundle["path"])
                 except subprocess.CalledProcessError:
                     pass
                 else:
                     # default LSMinimumSystemVersion == 10.0.0 (Apple Developer)
-                    v = plist.get('LSMinimumSystemVersion', '10.0')
+                    v = plist.get("LSMinimumSystemVersion", "10.0")
                     # some developers are dumb...
-                    v.replace(' ', '')
+                    v.replace(" ", "")
                     try:
                         versions.append(StrictVersion(v))
                     except ValueError as e:
                         self.log.error(f"invalid version: {v!r} (using default)")
-                        versions.append(StrictVersion('10.0'))
+                        versions.append(StrictVersion("10.0"))
             # minimum version is the HIGHEST version of all bundles
             # NOTE: if one component requires 10.14.6, but another requires
             #       10.2.0, then the lowest OS the app run on is 10.14.6
@@ -360,10 +364,10 @@ class Package:
             try:
                 self._min_os_ver = sorted(versions)[-1]
             except IndexError:
-                self._min_os_ver = StrictVersion('10.0')
+                self._min_os_ver = StrictVersion("10.0")
             # save the metadata for future use
             try:
-                xattr('-w', VERSIONKEY, self._min_os_ver, self.path)
+                xattr("-w", VERSIONKEY, self._min_os_ver, self.path)
             except subprocess.CalledProcessError:
                 self.log.error(f"xattr failed")
         return self._min_os_ver
@@ -372,24 +376,30 @@ class Package:
     def info(self):
         if not self._info:
             try:
-                _pkginfo = extract(self.path, 'PackageInfo', TMPDIR)
+                _pkginfo = extract(self.path, "PackageInfo", TMPDIR)
             except subprocess.CalledProcessError:
                 raise InvalidPackageError(self.path)
             _pkg = package_information(info=_pkginfo)
-            self._info = {'name': self.path.name,
-                          'path': str(self.path.absolute()),
-                          'pkginfo': _pkg['pkginfo']}
-            location = pathlib.Path(_pkg['pkginfo']['install-location'])
-            info_keys = ('CFBundleShortVersionString', 'CFBundleVersion')
+            self._info = {
+                "name": self.path.name,
+                "path": str(self.path.absolute()),
+                "pkginfo": _pkg["pkginfo"],
+            }
+            location = pathlib.Path(_pkg["pkginfo"]["install-location"])
+            info_keys = ("CFBundleShortVersionString", "CFBundleVersion")
             contents = []
-            for bundle in _pkg['bundles']:
+            for bundle in _pkg["bundles"]:
                 _info = {k: v for k, v in bundle.items() if k in info_keys}
-                path = location / bundle['path']
-                _info.update({'CFBundleIdentifier': bundle['id'],
-                              'name': path.name,
-                              'path': str(path)})
+                path = location / bundle["path"]
+                _info.update(
+                    {
+                        "CFBundleIdentifier": bundle["id"],
+                        "name": path.name,
+                        "path": str(path),
+                    }
+                )
                 contents.append(_info)
-            self._info['contents'] = contents
+            self._info["contents"] = contents
         return self._info
 
     @property
@@ -418,13 +428,14 @@ class Package:
             e = TMPDIR / self.path.stem
             if e.exists():
                 # check to see if the information matches
-                _extracted = extract(self.path, 'PackageInfo', e)
+                _extracted = extract(self.path, "PackageInfo", e)
                 _pkg = package_information(info=_extracted)
-                _exists = package_information(path=e/'PackageInfo')
+                _exists = package_information(path=e / "PackageInfo")
                 # continue with expansion if different, or use existing
                 # TO-DO: should probably test for empty directory
-                self.expanded = (expand_package(self.path, path=e, ov=True)
-                                 if _exists != _pkg else e)
+                self.expanded = (
+                    expand_package(self.path, path=e, ov=True) if _exists != _pkg else e
+                )
             else:
                 # no existing path was found
                 self.expanded = expand_package(self.path, path=e)
@@ -438,7 +449,7 @@ class Package:
         _checksums = calculate_checksums(self.path, hashes)
         self._md5, self._sha512 = [h.hexdigest() for h in _checksums]
 
-    def install(self, target='/'):
+    def install(self, target="/"):
         """
         convenience function to install this package
         """
@@ -510,11 +521,12 @@ class Repo:
     """
     Package Repository
     """
-    def __init__(self, path, pattern='*pkg'):
+
+    def __init__(self, path, pattern="*pkg"):
         self.log = logging.getLogger(f"{__name__}.Repo")
         self._config = None
         self.path = pathlib.Path(path).absolute()
-        self.archive = self.path / 'archive'
+        self.archive = self.path / "archive"
         # "*pkg" should match [*.mpkg, '*.pkg']
         self.pattern = pattern
         self._packages = None
@@ -528,19 +540,19 @@ class Repo:
             self._packages = []
             for path in self.path.glob(self.pattern):
                 # exclude hidden files
-                if not path.name.startswith('.'):
+                if not path.name.startswith("."):
                     self._packages.append(Package(path))
         return self._packages
 
     @property
     def category(self):
-        return self.config.get('category', 'No category assigned')
+        return self.config.get("category", "No category assigned")
 
     @property
     def config(self):
         # TO-DO: this should be handled by config.Config()
         if not self._config:
-            path = self.path / 'edu.utah.mlib.jctl.plist'
+            path = self.path / "edu.utah.mlib.jctl.plist"
             self._config = config.Config(path=path)
             if not self._config.load():
                 # TO-DO: need to create a template
@@ -609,7 +621,7 @@ class Repo:
 #     raise NotImplementedError()
 
 
-def install_package(pkg, target='/'):
+def install_package(pkg, target="/"):
     """
     Install a package
 
@@ -619,9 +631,9 @@ def install_package(pkg, target='/'):
     logger = logging.getLogger(__name__)
     path = pkg.path.absolute() if isinstance(pkg, Package) else pkg
     logger.info(f"installing package: {path}")
-    cmd = ['/usr/sbin/installer', '-pkg', path, '-target', target]
+    cmd = ["/usr/sbin/installer", "-pkg", path, "-target", target]
     logger.debug(f"> sudo -n installer -pkg {path!r} -target {target!r}")
-    subprocess.check_call(['/usr/bin/sudo', '-n'] + cmd)
+    subprocess.check_call(["/usr/bin/sudo", "-n"] + cmd)
 
 
 # def jss_package_details(api, name=None):
@@ -671,8 +683,8 @@ def jss_packages(jss, name=None):
     name = name.lower()
     pkgs = []
     # for pkg in jss.get('packages', xml=True)['packages']['package']:
-    for pkg in jss.get('packages')['packages']:
-        if not name or name in pkg['name'].lower():
+    for pkg in jss.get("packages")["packages"]:
+        if not name or name in pkg["name"].lower():
             pkgs.append(pkg)
     return pkgs
 
@@ -681,22 +693,22 @@ def installer_packages():
     """
     quick and dirty dump of packages on InstallerPackages
     """
-    vol = '/Volumes/InstallerPackages/munkipkg_projects'
+    vol = "/Volumes/InstallerPackages/munkipkg_projects"
     import glob
-    g = os.path.join(vol, '*/payload/*.app')
+
+    g = os.path.join(vol, "*/payload/*.app")
     info = {}
     for path in glob.glob(g):
         name = os.path.splitext(os.path.basename(path))[0]
-        directory = path.split('/payload')[0]
+        directory = path.split("/payload")[0]
         folder = os.path.basename(directory)
         pkgs = []
-        for pkg in glob.glob(os.path.join(directory, 'build/*.pkg')):
+        for pkg in glob.glob(os.path.join(directory, "build/*.pkg")):
             pkgs.append(os.path.basename(pkg))
-        plist = os.path.join(directory, 'build-info.plist')
-        with open(plist, 'rb') as f:
+        plist = os.path.join(directory, "build-info.plist")
+        with open(plist, "rb") as f:
             b_info = plistlib.load(f)
-        info[name] = {'pkgs': pkgs, 'folder': folder,
-                      'build': b_info, 'name': name}
+        info[name] = {"pkgs": pkgs, "folder": folder, "build": b_info, "name": name}
 
 
 def pkgutil(*args):
@@ -705,7 +717,7 @@ def pkgutil(*args):
     """
     logger = logging.getLogger(__name__)
     logger.debug(f"args: {args!r}")
-    cmd = ['/usr/sbin/pkgutil'] + [str(x) for x in args]
+    cmd = ["/usr/sbin/pkgutil"] + [str(x) for x in args]
     out = subprocess.check_output(cmd, stderr=subprocess.PIPE)
     try:
         result = plistlib.loads(out)
@@ -745,7 +757,7 @@ def expand_package(pkg, path=None, full=False, ov=False):
         logger.error(f"destination already exists: {expanded}")
         raise FileExistsError(expanded)
     # https://stackoverflow.com/questions/41166805/how-to-extract-contents-from-payload-file-in-a-apple-macos-update-package
-    expand_type = '--expand-full' if full else '--expand'
+    expand_type = "--expand-full" if full else "--expand"
     # will fail if parent directory does not exist
     pkgutil(expand_type, pkg, expanded)
     return expanded
@@ -766,8 +778,8 @@ def calculate_checksums(path, hashes, copy=True, bufsize=8192):
     logger.debug(f"calculating checksums: {path}")
     # copy each hash if specified, otherwise update original hash objects
     hashes = [hash.copy() if copy else hash for hash in hashes]
-    with open(path, 'rb') as f:
-        for chunk in iter(lambda: f.read(bufsize), b''):
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(bufsize), b""):
             # update each hash with the contents of file as it's read
             for hash in hashes:
                 hash.update(chunk)
@@ -780,7 +792,7 @@ def extract_info_plist(payload, app_path):
     :param payload <str|Path>:      path to zipped pkg payload
     :param app_path <str|Path>:     path to app to extract in payload
     """
-    path = pathlib.Path(app_path) / 'Contents' / 'Info.plist'
+    path = pathlib.Path(app_path) / "Contents" / "Info.plist"
     return plistlib.loads(extract_tar(path, payload))
 
 
@@ -788,7 +800,7 @@ def extract_tar(payload, path):
     logger = logging.getLogger(__name__)
     logger.info(f"extracting using tar: '{path}'")
     logger.info(f"> tar -xOf '{payload}' '{path}'")
-    tar_output = subprocess.check_output(['/usr/bin/tar', '-xOf', path, payload])
+    tar_output = subprocess.check_output(["/usr/bin/tar", "-xOf", path, payload])
     return tar_output
 
 
@@ -798,9 +810,11 @@ def extract(path, payload, save_dir):
     if not TMPDIR.exists():
         TMPDIR.mkdir(mode=0o755)
     logger.debug(f"> xar -xf '{path}' '{payload}' -C '{save_dir}'")
-    xar_output = subprocess.check_output(['/usr/bin/xar', '-xf', path, payload, '-C', save_dir])
-    pkg_info = subprocess.check_output(['/bin/cat', save_dir / payload])
-    return (pkg_info)
+    xar_output = subprocess.check_output(
+        ["/usr/bin/xar", "-xf", path, payload, "-C", save_dir]
+    )
+    pkg_info = subprocess.check_output(["/bin/cat", save_dir / payload])
+    return pkg_info
 
 
 def find_payload(archive):
@@ -808,7 +822,7 @@ def find_payload(archive):
     locate payload inside of an archive
     """
     # https://dev.to/aarohmankad/bash-functions-a-more-powerful-alias-4p3i
-    cmd = ['/usr/bin/xar', '-tf', archive]
+    cmd = ["/usr/bin/xar", "-tf", archive]
     raise NotImplementedError()
 
 
@@ -839,26 +853,26 @@ def package_information(path=None, info=None):
         raise TypeError("must specify path or string")
 
     # verify root tag == 'pkg-info'
-    if root.tag != 'pkg-info':
+    if root.tag != "pkg-info":
         raise Error(f"unexpected xml tag: {root.tag!r} != 'pkg-info'")
     # unsure if this is necessary (I haven't seen anything other than 2)
-    fmt_ver = int(root.attrib['format-version'])
+    fmt_ver = int(root.attrib["format-version"])
     if fmt_ver != 2:
         logger.debug("unsure if this error can be ignored")
         raise Error(f"unexpected 'format-version': {fmt_ver} != 2")
     # get information about package
     _pkginfo = root.attrib.copy()
-    _pkginfo.setdefault('install-location', '/')
-    info = {'pkginfo': _pkginfo, 'bundles': []}
+    _pkginfo.setdefault("install-location", "/")
+    info = {"pkginfo": _pkginfo, "bundles": []}
 
     # get a list of bundle-ids that we care about
-    ids = [e.attrib['id'] for e in root.findall('bundle-version/bundle')]
+    ids = [e.attrib["id"] for e in root.findall("bundle-version/bundle")]
     # find all bundles that are installed and get information about each one
-    for e in root.findall('bundle'):
-        id_ = e.attrib.get('id')
+    for e in root.findall("bundle"):
+        id_ = e.attrib.get("id")
         if id_ and id_ in ids:
             # only get attributes for bundles in 'pkg-info/bundle-version'
-            info['bundles'].append(e.attrib.copy())
+            info["bundles"].append(e.attrib.copy())
     return info
 
 
@@ -868,6 +882,6 @@ def xattr(*args):
     """
     logger = logging.getLogger(__name__)
     logger.debug(f"xattr args: {args!r}")
-    cmd = ['/usr/bin/xattr'] + [str(x) for x in args]
+    cmd = ["/usr/bin/xattr"] + [str(x) for x in args]
     out = subprocess.check_output(cmd, stderr=subprocess.PIPE)
-    return out.decode('utf-8').rstrip()
+    return out.decode("utf-8").rstrip()

--- a/jamf/records.py
+++ b/jamf/records.py
@@ -15,15 +15,15 @@ Copyright (c) 2020 University of Utah, Marriott Library
 Copyright (c) 2020 Tony Williams
 """
 
-__author__ = 'James Reynolds, Sam Forester, Tony Williams'
-__email__ = 'reynolds@biology.utah.edu, sam.forester@utah.edu, tonyw@honestpuck.com'
-__copyright__ = 'Copyright (c) 2021 University of Utah, School of Biological Sciences and Copyright (c) 2020 Tony Williams'
-__license__ = 'MIT'
-__date__ = '2020-09-21'
+__author__ = "James Reynolds, Sam Forester, Tony Williams"
+__email__ = "reynolds@biology.utah.edu, sam.forester@utah.edu, tonyw@honestpuck.com"
+__copyright__ = "Copyright (c) 2021 University of Utah, School of Biological Sciences and Copyright (c) 2020 Tony Williams"
+__license__ = "MIT"
+__date__ = "2020-09-21"
 __version__ = "0.4.3"
 
 
-#pylint: disable=relative-beyond-top-level
+# pylint: disable=relative-beyond-top-level
 from .api import API
 from pprint import pprint
 import json
@@ -33,72 +33,79 @@ import re
 import sys
 
 __all__ = (
-    'AdvancedComputerSearches',
-    'AdvancedMobileDeviceSearches',
-    'AdvancedUserSearches',
-    'Buildings',
-    'BYOProfiles',
-    'Categories',
-    'Classes',
-    'ComputerConfigurations',
-    'ComputerExtensionAttributes',
-    'ComputerGroups',
-    'ComputerReports',
-    'Computers',
-    'Departments',
-    'DirectoryBindings',
-    'DiskEncryptionConfigurations',
-    'DistributionPoints',
-    'DockItems',
-    'Ebooks',
-    'Ibeacons',
-    'JSONWebTokenConfigurations',
-    'LDAPServers',
-    'MacApplications',
-    'ManagedPreferenceProfiles',
-    'MobileDeviceApplications',
-    'MobileDeviceCommands',
-    'MobileDeviceConfigurationProfiles',
-    'MobileDeviceEnrollmentProfiles',
-    'MobileDeviceExtensionAttributes',
-    'MobileDeviceInvitations',
-    'MobileDeviceProvisioningProfiles',
-    'MobileDevices',
-    'NetbootServers',
-    'NetworkSegments',
-    'OSXConfigurationProfiles',
-    'Packages',
-    'PatchExternalSources',
-    'PatchInternalSources',
-    'PatchPolicies',
-    'PatchSoftwareTitles',
-    'Peripherals',
-    'PeripheralTypes',
-    'Policies',
-    'Printers',
-    'RemovableMACAddresses',
-    'Scripts',
-    'Sites',
-    'SoftwareUpdateServers',
-    'UserExtensionAttributes',
-    'UserGroups',
-    'Users',
-    'VPPAccounts',
-    'VPPAssignments',
-    'VPPInvitations',
-    'WebHooks',
+    "AdvancedComputerSearches",
+    "AdvancedMobileDeviceSearches",
+    "AdvancedUserSearches",
+    "Buildings",
+    "BYOProfiles",
+    "Categories",
+    "Classes",
+    "ComputerConfigurations",
+    "ComputerExtensionAttributes",
+    "ComputerGroups",
+    "ComputerReports",
+    "Computers",
+    "Departments",
+    "DirectoryBindings",
+    "DiskEncryptionConfigurations",
+    "DistributionPoints",
+    "DockItems",
+    "Ebooks",
+    "Ibeacons",
+    "JSONWebTokenConfigurations",
+    "LDAPServers",
+    "MacApplications",
+    "ManagedPreferenceProfiles",
+    "MobileDeviceApplications",
+    "MobileDeviceCommands",
+    "MobileDeviceConfigurationProfiles",
+    "MobileDeviceEnrollmentProfiles",
+    "MobileDeviceExtensionAttributes",
+    "MobileDeviceInvitations",
+    "MobileDeviceProvisioningProfiles",
+    "MobileDevices",
+    "NetbootServers",
+    "NetworkSegments",
+    "OSXConfigurationProfiles",
+    "Packages",
+    "PatchExternalSources",
+    "PatchInternalSources",
+    "PatchPolicies",
+    "PatchSoftwareTitles",
+    "Peripherals",
+    "PeripheralTypes",
+    "Policies",
+    "Printers",
+    "RemovableMACAddresses",
+    "Scripts",
+    "Sites",
+    "SoftwareUpdateServers",
+    "UserExtensionAttributes",
+    "UserGroups",
+    "Users",
+    "VPPAccounts",
+    "VPPAssignments",
+    "VPPInvitations",
+    "WebHooks",
     # Add all non-Jamf Record classes to the exclude list in valid_records below
-    'JamfError')
+    "JamfError",
+)
+
 
 def valid_records():
-    valid = tuple(x for x in __all__ if not x in [
-        # Exclude list, add all non-Jamf Record classes here
-        'JamfError'
-    ])
+    valid = tuple(
+        x
+        for x in __all__
+        if not x
+        in [
+            # Exclude list, add all non-Jamf Record classes here
+            "JamfError"
+        ]
+    )
     return valid
 
 
-#pylint: disable=eval-used
+# pylint: disable=eval-used
 def class_name(name, case_sensitive=True):
     if case_sensitive and name in valid_records():
         return eval(name)
@@ -109,18 +116,22 @@ def class_name(name, case_sensitive=True):
     raise JamfError(f"{name} is not a valid record.")
 
 
-#pylint: disable=super-init-not-called
+# pylint: disable=super-init-not-called
 class JamfError(Exception):
     def __init__(self, message):
         self.message = message
 
-#pylint: disable=super-init-not-called
+
+# pylint: disable=super-init-not-called
 class NotFound(Exception):
     pass
 
+
 class Singleton(type):
-    """ allows us to share a single object """
+    """allows us to share a single object"""
+
     _instances = {}
+
     def __call__(cls, *a, **kw):
         if cls not in cls._instances:
             cls._instances[cls] = super(Singleton, cls).__call__(*a, **kw)
@@ -129,105 +140,103 @@ class Singleton(type):
 
 class ClassicSwagger(metaclass=Singleton):
     def __init__(self):
-        self._swagger = json.load(open(os.path.dirname(__file__)+'/records.json', 'r'))
-        self._broken_api = [
-        ]
-        post_template2 = {'general':{'name':'%NAME%'}}
+        self._swagger = json.load(
+            open(os.path.dirname(__file__) + "/records.json", "r")
+        )
+        self._broken_api = []
+        post_template2 = {"general": {"name": "%NAME%"}}
         self._post_templates = {
-            'BYOProfiles': post_template2,
-            'ComputerConfigurations': post_template2,
-            'ComputerReports': post_template2,
-            'DirectoryBindings': post_template2,
-            'Ebooks': post_template2,
-            'JSONWebTokenConfigurations': post_template2,
-#            'LicensedSoftware': post_template2,
-#            'LDAPServers': post_template2,
-            'MacApplications': post_template2,
-            'ManagedPreferenceProfiles': post_template2,
-            'MobileDevices': post_template2,
-            'MobileDeviceApplications': post_template2,
-            'MobileDeviceConfigurationProfiles': post_template2,
-            'MobileDeviceEnrollmentProfiles': post_template2,
-            'MobileDeviceProvisioningProfiles': post_template2,
-            'OSXConfigurationProfiles': post_template2,
-            'PatchPolicies': post_template2,
-            'Peripherals': post_template2,
-            'Policies': post_template2,
-            'SoftwareUpdateServers': post_template2,
-            'VPPAccounts': post_template2,
-            'VPPAssignments': post_template2,
-            'VPPInvitations': post_template2,
-
-            'ComputerGroups': {'name':'%NAME%','is_smart':True},
-            'DistributionPoints': {
-                'name':'%NAME%',
-                'read_only_username':'read_only_username',
-                'read_write_username':'read_write_username',
-                'share_name':'files'
+            "BYOProfiles": post_template2,
+            "ComputerConfigurations": post_template2,
+            "ComputerReports": post_template2,
+            "DirectoryBindings": post_template2,
+            "Ebooks": post_template2,
+            "JSONWebTokenConfigurations": post_template2,
+            #            'LicensedSoftware': post_template2,
+            #            'LDAPServers': post_template2,
+            "MacApplications": post_template2,
+            "ManagedPreferenceProfiles": post_template2,
+            "MobileDevices": post_template2,
+            "MobileDeviceApplications": post_template2,
+            "MobileDeviceConfigurationProfiles": post_template2,
+            "MobileDeviceEnrollmentProfiles": post_template2,
+            "MobileDeviceProvisioningProfiles": post_template2,
+            "OSXConfigurationProfiles": post_template2,
+            "PatchPolicies": post_template2,
+            "Peripherals": post_template2,
+            "Policies": post_template2,
+            "SoftwareUpdateServers": post_template2,
+            "VPPAccounts": post_template2,
+            "VPPAssignments": post_template2,
+            "VPPInvitations": post_template2,
+            "ComputerGroups": {"name": "%NAME%", "is_smart": True},
+            "DistributionPoints": {
+                "name": "%NAME%",
+                "read_only_username": "read_only_username",
+                "read_write_username": "read_write_username",
+                "share_name": "files",
             },
-            'DockItems': {
-                'name':'%NAME%',
-                'path':'file://localhost/Applications/Safari.app/', 'type':'App'
+            "DockItems": {
+                "name": "%NAME%",
+                "path": "file://localhost/Applications/Safari.app/",
+                "type": "App",
             },
-            'Ibeacons': {
-                'name':'%NAME%',
-                'uuid': '7710B6A4-FD29-4647-B2F4-B3FA645146A8' # I don't have iBeacons, I don't know the purpose of this value, I got it with `uuidgen` (https://support.twocanoes.com/hc/en-us/articles/203081205-Managing-Printers-with-iBeacons)
+            "Ibeacons": {
+                "name": "%NAME%",
+                "uuid": "7710B6A4-FD29-4647-B2F4-B3FA645146A8",  # I don't have iBeacons, I don't know the purpose of this value, I got it with `uuidgen` (https://support.twocanoes.com/hc/en-us/articles/203081205-Managing-Printers-with-iBeacons)
             },
-            'NetbootServers': {'name':'%NAME%','ip_address':'10.0.0.1'},
-            'NetworkSegments': {
-                'name':'%NAME%',
-                'starting_address':'10.0.0.1',
-                'ending_address':'10.0.0.1'
+            "NetbootServers": {"name": "%NAME%", "ip_address": "10.0.0.1"},
+            "NetworkSegments": {
+                "name": "%NAME%",
+                "starting_address": "10.0.0.1",
+                "ending_address": "10.0.0.1",
             },
-            'Packages': {
-                'name':'%NAME%',
-                'filename': 'filename.pkg',
+            "Packages": {
+                "name": "%NAME%",
+                "filename": "filename.pkg",
             },
-            'PatchExternalSources': {
-                'name':'%NAME%',
-                'host_name':'example.com',
+            "PatchExternalSources": {
+                "name": "%NAME%",
+                "host_name": "example.com",
             },
-            'PatchSoftwareTitles': {'name':'%NAME%', 'source_id':'1'},
-#            'RestrictedSoftware': {'general':{'name':'%NAME%','process_name':'%NAME%'}},
-            'UserGroups': {
-                'general':{'name':'%NAME%'},
-                'is_smart':False
-            },
-            'WebHooks': {
-                'event': 'ComputerAdded',
-                'name':'%NAME%',
-                'url': 'http:/example.com',
+            "PatchSoftwareTitles": {"name": "%NAME%", "source_id": "1"},
+            #            'RestrictedSoftware': {'general':{'name':'%NAME%','process_name':'%NAME%'}},
+            "UserGroups": {"general": {"name": "%NAME%"}, "is_smart": False},
+            "WebHooks": {
+                "event": "ComputerAdded",
+                "name": "%NAME%",
+                "url": "http:/example.com",
             },
         }
         self._swagger_fixes = {
-            'ComputerConfigurations':{
-                's2':'configuration',
+            "ComputerConfigurations": {
+                "s2": "configuration",
             },
-            'ComputerReports': {
-                's1':'computer_reports',
+            "ComputerReports": {
+                "s1": "computer_reports",
             },
-            'MobileDeviceCommands': {
-                'id_text1':'uuid',
-                'id_text2':'uuid',
+            "MobileDeviceCommands": {
+                "id_text1": "uuid",
+                "id_text2": "uuid",
             },
-            'RestrictedSoftware': {
-                'p3':'restricted_software_title',
-                's1':'restricted_software'
+            "RestrictedSoftware": {
+                "p3": "restricted_software_title",
+                "s1": "restricted_software",
             },
         }
 
     def post_template(self, className, name):
         if className in self._post_templates:
             template = self._post_templates[className]
-            if 'name' in template:
-                template['name'] = template['name'].replace('%NAME%', name)
-            elif 'name_id' in template:
-                template['name_id'] = template['name_id'].replace('%NAME%', name)
-            elif 'general' in template and 'name' in template['general']:
-                t = template['general']['name']
-                template['general']['name'] = t.replace('%NAME%', name)
+            if "name" in template:
+                template["name"] = template["name"].replace("%NAME%", name)
+            elif "name_id" in template:
+                template["name_id"] = template["name_id"].replace("%NAME%", name)
+            elif "general" in template and "name" in template["general"]:
+                t = template["general"]["name"]
+                template["general"]["name"] = t.replace("%NAME%", name)
         else:
-            template = {'name':name}
+            template = {"name": name}
         return template
 
     def swagger(self, cls, kk):
@@ -236,98 +245,98 @@ class ClassicSwagger(metaclass=Singleton):
             fixes = self._swagger_fixes[cls.__name__]
 
         # The endpoint url, e.g. "Policies" class becomes "policies" endpoint
-        if 'p1' in fixes:
-            p1 = fixes['p1']
+        if "p1" in fixes:
+            p1 = fixes["p1"]
         else:
             p1 = cls.__name__.lower()
-        if kk == 'path_name':
+        if kk == "path_name":
             return p1
 
         # Get the definition name, which almost always is the plural name
         # exceptions: LicensedSoftware, RestrictedSoftware?
-        if 'p2' in fixes:
-            p2 = fixes['p2']
+        if "p2" in fixes:
+            p2 = fixes["p2"]
         else:
             p2 = self.get_schema(p1)
             # If there's an xml entry, use it for the definition name
-            temp2 = self._swagger['definitions'][p2]
-            if ('xml' in temp2 and 'name' in temp2['xml']):
-                p2 = temp2['xml']['name']
-        if kk == 'def_name':
+            temp2 = self._swagger["definitions"][p2]
+            if "xml" in temp2 and "name" in temp2["xml"]:
+                p2 = temp2["xml"]["name"]
+        if kk == "def_name":
             return p2
 
-        if 'id_text1' in fixes:
-            id1 = fixes['id_text1']
+        if "id_text1" in fixes:
+            id1 = fixes["id_text1"]
         else:
-            id1 = 'id'
-        if kk == 'id1':
+            id1 = "id"
+        if kk == "id1":
             return id1
 
-        if kk == 'p1, id1':
+        if kk == "p1, id1":
             return p1, id1
 
-        end = f'{p1}/{id1}/'
+        end = f"{p1}/{id1}/"
 
-        if kk == 'end':
+        if kk == "end":
             return end
 
-        if 'id_text2' in fixes:
-            id2 = fixes['id_text2']
+        if "id_text2" in fixes:
+            id2 = fixes["id_text2"]
         else:
-            id2 = 'id'
-        if kk == 'id2':
+            id2 = "id"
+        if kk == "id2":
             return id2
 
         # Get the schema, which almost always is the singular name
-        if 'p3' in fixes:
-            p3 = fixes['p3']
+        if "p3" in fixes:
+            p3 = fixes["p3"]
         else:
             temp1 = f"{p1}/{id1}/{{{id2}}}"
             p3 = self.get_schema(temp1)
-        if kk == 'p3':
+        if kk == "p3":
             return p3
 
-        if kk == 'p1, p2, id1, p3':
+        if kk == "p1, p2, id1, p3":
             return p1, p2, id1, p3
 
         # Singular, which almost always is the p3
-        if 's1' in fixes:
-            s1 = fixes['s1']
+        if "s1" in fixes:
+            s1 = fixes["s1"]
         else:
             s1 = p3
-        if kk == 's1':
+        if kk == "s1":
             return s1
 
         # This is the name of the endpoint when it's returned from a post
         # e.g. ComputerConfigurations: {'configuration': {'general': {'name': 'rfwlkzis'}}}
-        if 's2' in fixes:
-            s2 = fixes['s2']
+        if "s2" in fixes:
+            s2 = fixes["s2"]
         else:
             s2 = s1
-        if kk == 's2':
+        if kk == "s2":
             return s2
 
-        if kk == 's1, end':
+        if kk == "s1, end":
             return s1, end
 
-        if kk == 's1, s2, end':
+        if kk == "s1, s2, end":
             return s1, s2, end
 
     def get_schema(self, swagger_path):
-        temp1 = self._swagger['paths']['/'+swagger_path]['get']
-        schema = temp1['responses']['200']['schema']['$ref']
+        temp1 = self._swagger["paths"]["/" + swagger_path]["get"]
+        schema = temp1["responses"]["200"]["schema"]["$ref"]
         if schema.startswith("#/definitions/"):
             schema = schema[14:]
         return schema
 
     def is_action_valid(self, className, action):
-        p1, id1 = self.swagger(className, 'p1, id1')
-        p = f'/{p1}/{id1}/{{{id1}}}'
+        p1, id1 = self.swagger(className, "p1, id1")
+        p = f"/{p1}/{id1}/{{{id1}}}"
         if className == PatchPolicies and action == "post":
-            p = '/patchpolicies/softwaretitleconfig/id/{softwaretitleconfigid}'
+            p = "/patchpolicies/softwaretitleconfig/id/{softwaretitleconfigid}"
         if p in self._broken_api:
             return False
-        return p in self._swagger['paths'] and action in self._swagger['paths'][p]
+        return p in self._swagger["paths"] and action in self._swagger["paths"][p]
 
 
 class Record:
@@ -358,20 +367,24 @@ class Record:
         api = API()
         _data = {}
         if jamf_id == 0:
-            if not swag.is_action_valid(plural, 'post'):
-                print(f"Creating a new record with an id of 0 causes a post, "
-                      f"which isn't a valid action for the {cls.plural_class} "
-                      f"record type.")
+            if not swag.is_action_valid(plural, "post"):
+                print(
+                    f"Creating a new record with an id of 0 causes a post, "
+                    f"which isn't a valid action for the {cls.plural_class} "
+                    f"record type."
+                )
                 return None
-            s1, s2, end = swag.swagger(plural, 's1, s2, end')
+            s1, s2, end = swag.swagger(plural, "s1, s2, end")
             if cls.plural_class == "PatchPolicies":
-                print("Use /patchpolicies/softwaretitleconfig/id/{softwaretitleconfigid}"
-                      " instead")
+                print(
+                    "Use /patchpolicies/softwaretitleconfig/id/{softwaretitleconfigid}"
+                    " instead"
+                )
                 return None
             end = f"{end}0"
             out = {s1: swag.post_template(cls.plural_class, name)}
             _data = api.post(end, out)
-            jamf_id = int(_data[s2]['id'])
+            jamf_id = int(_data[s2]["id"])
         if jamf_id not in cls._instances:
             rec = super(Record, cls).__new__(cls)
             rec.cls = cls
@@ -392,18 +405,18 @@ class Record:
         elif isinstance(x, int):
             return self.id == x
         elif isinstance(x, str):
-            if x.isdigit() or x == '-1':
+            if x.isdigit() or x == "-1":
                 return self.id == int(x)
             else:
                 return self.name == x
         elif isinstance(x, dict):
-            jamf_id = int(x.get('id', -1))
-            return self.name == x.get('name') and self.id == jamf_id
+            jamf_id = int(x.get("id", -1))
+            return self.name == x.get("name") and self.id == jamf_id
         else:
             raise TypeError(f"can't test equality of {x!r}")
 
     def __lt__(self, x):
-        if ( self.name and x.name and self.name < x.name ):
+        if self.name and x.name and self.name < x.name:
             return True
         return False
 
@@ -417,10 +430,10 @@ class Record:
         return f"{self.__class__.__name__}({self.id}, {self.name!r})"
 
     def refresh(self):
-        s1, end = self.s.swagger(self.plural, 's1, end')
+        s1, end = self.s.swagger(self.plural, "s1, end")
         end = f"{end}{self.id}"
-        if not self.s.is_action_valid(self.plural, 'get'):
-            raise JamfError(f'get({end}) is an invalid action for get')
+        if not self.s.is_action_valid(self.plural, "get"):
+            raise JamfError(f"get({end}) is an invalid action for get")
         results = self.api.get(end)
         if not s1 in results:
             print("---------------------------------------------\nData dump\n")
@@ -432,17 +445,17 @@ class Record:
             self._data = {}
 
     def delete(self):
-        end = self.s.swagger(self.plural, 'end')
+        end = self.s.swagger(self.plural, "end")
         end = f"{end}{self.id}"
-        if not self.s.is_action_valid(self.plural, 'delete'):
-            raise JamfError(f'{end} is an invalid endpoint for delete')
+        if not self.s.is_action_valid(self.plural, "delete"):
+            raise JamfError(f"{end} is an invalid endpoint for delete")
         return self.api.delete(end)
 
     def save(self):
-        s1, end = self.s.swagger(self.plural, 's1, end')
+        s1, end = self.s.swagger(self.plural, "s1, end")
         end = f"{end}{self.id}"
-        if not self.s.is_action_valid(self.plural, 'put'):
-            raise JamfError(f'{end} is an invalid endpoint for put')
+        if not self.s.is_action_valid(self.plural, "put"):
+            raise JamfError(f"{end} is an invalid endpoint for put")
         out = {s1: self._data}
         return self.api.put(end, out)
 
@@ -456,9 +469,9 @@ class Record:
         current = path[index]
         if type(placeholder) is dict:
             if current in placeholder:
-                if index+1 >= len(path):
+                if index + 1 >= len(path):
                     return placeholder[current]
-                placeholder = self.get_path2(path, placeholder[current], index+1)
+                placeholder = self.get_path2(path, placeholder[current], index + 1)
             else:
                 return None
         elif type(placeholder) is list:
@@ -466,8 +479,8 @@ class Record:
             result = []
             for item in placeholder:
                 if current in item:
-                    if index+1 < len(path):
-                        result.append(self.get_path2(path, item[current], index+1))
+                    if index + 1 < len(path):
+                        result.append(self.get_path2(path, item[current], index + 1))
                     else:
                         result.append(item[current])
             placeholder = result
@@ -482,7 +495,7 @@ class Record:
         if not self._data:
             self.refresh()
         try:
-            result = self.get_path2(path.split('/'), self._data)
+            result = self.get_path2(path.split("/"), self._data)
         except NotFound as error:
             print("Not Found")
             result = []
@@ -492,8 +505,8 @@ class Record:
 
     def force_array(self, parent, child_name):
         _data = parent[child_name]
-        if 'size' in parent:
-            if int(parent['size']) > 1:
+        if "size" in parent:
+            if int(parent["size"]) > 1:
                 return _data
         else:
             if type(_data) is list:
@@ -501,7 +514,7 @@ class Record:
         return [_data]
 
     def set_path(self, path, value):
-        temp1 = path.split('/')
+        temp1 = path.split("/")
         endpoint = temp1.pop()
         temp2 = "/".join(temp1)
         if len(temp2) > 0:
@@ -541,7 +554,7 @@ class RecordsIterator:
         raise StopIteration
 
 
-class Records():
+class Records:
     """
     A class for a list of objects on Jamf Pro
 
@@ -610,36 +623,38 @@ class Records():
         return found
 
     def refresh(self):
-        p1, p2, id1, p3 = self.s.swagger(self.cls, 'p1, p2, id1, p3')
-        lst = self.api.get(p1)           # e.g. categories
+        p1, p2, id1, p3 = self.s.swagger(self.cls, "p1, p2, id1, p3")
+        lst = self.api.get(p1)  # e.g. categories
         if p2 in lst:
             self.data = lst[p2]
-            if not self.data or not 'size' in self.data or self.data['size'] == '0':
+            if not self.data or not "size" in self.data or self.data["size"] == "0":
                 self._records = {}
                 self._names = {}
                 self._jamf_ids = {}
-            elif p3 in self.data:         # e.g. category
-                if self.data['size'] == '1':
+            elif p3 in self.data:  # e.g. category
+                if self.data["size"] == "1":
                     records = [self.data[p3]]
                 else:
                     records = self.data[p3]
                 for d in records:
-                    c = self.singular_class(d[id1], d['name'])# e.g. id
+                    c = self.singular_class(d[id1], d["name"])  # e.g. id
                     c.plural_class = self.cls
-                    self._records.setdefault(int(d[id1]), c)# e.g. id
+                    self._records.setdefault(int(d[id1]), c)  # e.g. id
                     self._names.setdefault(c.name, c)
                     self._jamf_ids.setdefault(c.id, c)
             else:
                 pprint(self.data)
-                raise JamfError(f"Endpoint {p1} - "
-                                f"{p2} has no member named "
-                                f"{p3} (p3).")
+                raise JamfError(
+                    f"Endpoint {p1} - " f"{p2} has no member named " f"{p3} (p3)."
+                )
         else:
-            raise JamfError(f"Endpoint {p1} has no "
-                            f"member named {p2}. Check "
-                            f"the swagger definition file for the name of "
-                            f"{p1} and set the property "
-                            f"p2 for class ({p1}).")
+            raise JamfError(
+                f"Endpoint {p1} has no "
+                f"member named {p2}. Check "
+                f"the swagger definition file for the name of "
+                f"{p1} and set the property "
+                f"p2 for class ({p1})."
+            )
 
     def createNewRecord(self, args):
         return self.singular_class(0, args)
@@ -656,15 +671,15 @@ class Records():
             except ValueError:
                 result = self._names.get(x)
         elif isinstance(x, dict):
-            keys = ('id', 'jamf_id', 'name')
+            keys = ("id", "jamf_id", "name")
             try:
                 key = [k for k in x.keys() if k in keys][0]
             except IndexError:
                 result = None
             else:
-                if key in ('id', 'jamf_id'):
+                if key in ("id", "jamf_id"):
                     result = self._jamf_ids.get(int(x[key]))
-                elif key == 'name':
+                elif key == "name":
                     result = self._names.get(key)
         elif isinstance(x, Record):
             result = x
@@ -737,11 +752,12 @@ class Classes(Records, metaclass=Singleton):
 
 class Computer(Record):
     plural_class = "Computers"
+
     def apps_print_during(self):
         plural_cls = eval(self.cls.plural_class)
-        if not hasattr(plural_cls, 'app_list'):
+        if not hasattr(plural_cls, "app_list"):
             plural_cls.app_list = {}
-        if not hasattr(plural_cls, 'computers'):
+        if not hasattr(plural_cls, "computers"):
             plural_cls.computers = {}
         plural_cls.computers[self.name] = True
         apps = self.get_path("software/applications/application/path")
@@ -755,29 +771,26 @@ class Computer(Record):
                     plural_cls.app_list[app][ver] = {}
                 plural_cls.app_list[app][ver][self.name] = True
 
+
 class Computers(Records, metaclass=Singleton):
     # http://localhost/computers.html?queryType=COMPUTERS&query=
     singular_class = Computer
-    sub_commands = {
-        'apps': {
-            'required_args': 0,
-            'args_description': ''
-        }
-    }
+    sub_commands = {"apps": {"required_args": 0, "args_description": ""}}
+
     def apps_print_after(self):
-        print("application,version,", end='')
+        print("application,version,", end="")
         for computer in self.computers:
-            print(computer, ",", end='')
+            print(computer, ",", end="")
         print("")
         for app, versions in self.app_list.items():
             for version, bla in versions.items():
-                text = f"\"{app}\",\"{version}\","
-                print(text, end='')
+                text = f'"{app}","{version}",'
+                print(text, end="")
                 for computer in self.computers:
                     if computer in bla:
-                        print("X,", end='')
+                        print("X,", end="")
                     else:
-                        print(",", end='')
+                        print(",", end="")
                 print("")
 
 
@@ -1002,26 +1015,26 @@ class Package(Record):
 
     @property
     def metadata(self):
-        if not hasattr(self, 'meta'):
+        if not hasattr(self, "meta"):
             self._metadata = {}
             m = re.match("([^-]*)-(.*)\.([^\.]*)$", self.name)
             if m:
-                self._metadata['basename'] = m[1]
-                self._metadata['version'] = m[2]
-                self._metadata['filetype'] = m[3]
+                self._metadata["basename"] = m[1]
+                self._metadata["version"] = m[2]
+                self._metadata["filetype"] = m[3]
             else:
                 m = re.match("([^-]*)\.([^\.]*)$", self.name)
                 if m:
-                    self._metadata['basename'] = m[1]
-                    self._metadata['version'] = ""
-                    self._metadata['filetype'] = m[2]
+                    self._metadata["basename"] = m[1]
+                    self._metadata["version"] = ""
+                    self._metadata["filetype"] = m[2]
                 else:
-                    self._metadata['basename'] = self.name
-                    self._metadata['version'] = ""
-                    self._metadata['filetype'] = ""
-            if not self._metadata['basename'] in self.plural.groups:
-                self.plural.groups[self._metadata['basename']] = []
-            self.plural.groups[self._metadata['basename']].append(self)
+                    self._metadata["basename"] = self.name
+                    self._metadata["version"] = ""
+                    self._metadata["filetype"] = ""
+            if not self._metadata["basename"] in self.plural.groups:
+                self.plural.groups[self._metadata["basename"]] = []
+            self.plural.groups[self._metadata["basename"]].append(self)
         return self._metadata
 
     def refresh_related(self):
@@ -1039,11 +1052,11 @@ class Package(Record):
                         patchsoftwaretitles_ids[str(title.id)] = {}
                     patchsoftwaretitles_ids[str(title.id)][versions[ii]] = pkg
                     if not pkg in related:
-                        related[pkg] = {'patchsoftwaretitles':[]}
-                    if not 'patchsoftwaretitles' in related[pkg]:
-                        related[pkg]['patchsoftwaretitles'] = []
-                    temp = title.name+" - "+versions[ii]
-                    related[pkg]['patchsoftwaretitles'].append(temp)
+                        related[pkg] = {"patchsoftwaretitles": []}
+                    if not "patchsoftwaretitles" in related[pkg]:
+                        related[pkg]["patchsoftwaretitles"] = []
+                    temp = title.name + " - " + versions[ii]
+                    related[pkg]["patchsoftwaretitles"].append(temp)
         patchpolicies = jamf_records(PatchPolicies)
         for policy in patchpolicies:
             parent_id = policy.get_path("software_title_configuration_id")[0]
@@ -1053,20 +1066,20 @@ class Package(Record):
                 if parent_version in ppp:
                     pkg = ppp[parent_version]
                     if not pkg in related:
-                        related[pkg] = {'patchpolicies':[]}
-                    if not 'patchpolicies' in related[pkg]:
-                        related[pkg]['patchpolicies'] = []
-                    related[pkg]['patchpolicies'].append(policy.name)
+                        related[pkg] = {"patchpolicies": []}
+                    if not "patchpolicies" in related[pkg]:
+                        related[pkg]["patchpolicies"] = []
+                    related[pkg]["patchpolicies"].append(policy.name)
         policies = jamf_records(Policies)
         for policy in policies:
             pkgs = policy.get_path("package_configuration/packages/package/name")
             if pkgs:
                 for pkg in pkgs:
                     if not pkg in related:
-                        related[pkg] = {'policies':[]}
-                    if not 'policies' in related[pkg]:
-                        related[pkg]['policies'] = []
-                    related[pkg]['policies'].append(policy.name)
+                        related[pkg] = {"policies": []}
+                    if not "policies" in related[pkg]:
+                        related[pkg]["policies"] = []
+                    related[pkg]["policies"].append(policy.name)
         groups = jamf_records(ComputerGroups)
         for group in groups:
             criterions = group.get_path("criteria/criterion/value")
@@ -1074,15 +1087,15 @@ class Package(Record):
                 for pkg in criterions:
                     if pkg and re.search(".pkg|.zip|.dmg", pkg[-4:]):
                         if not pkg in related:
-                            related[pkg] = {'groups':[]}
-                        if not 'groups' in related[pkg]:
-                            related[pkg]['groups'] = []
-                        related[pkg]['groups'].append(group.name)
+                            related[pkg] = {"groups": []}
+                        if not "groups" in related[pkg]:
+                            related[pkg]["groups"] = []
+                        related[pkg]["groups"].append(group.name)
         self.__class__._related = related
 
     @property
     def related(self):
-        if not hasattr(self.__class__, '_related'):
+        if not hasattr(self.__class__, "_related"):
             self.refresh_related()
         if self.name in self.__class__._related:
             return self.__class__._related[self.name]
@@ -1091,22 +1104,22 @@ class Package(Record):
 
     def usage_print_during(self):
         related = self.related
-        if 'patchsoftwaretitles' in related:
+        if "patchsoftwaretitles" in related:
             print(self.name)
         else:
             print(f"{self.name} [no patch defined]")
-        if 'policies' in related:
+        if "policies" in related:
             print("  Policies")
-            for x in related['policies']:
-                print("    "+x)
-        if 'groups' in related:
+            for x in related["policies"]:
+                print("    " + x)
+        if "groups" in related:
             print("  ComputerGroups")
-            for x in related['groups']:
-                print("    "+x)
-        if 'patchpolicies' in related:
+            for x in related["groups"]:
+                print("    " + x)
+        if "patchpolicies" in related:
             print("  PatchPolicies")
-            for x in related['patchpolicies']:
-                print("    "+x)
+            for x in related["patchpolicies"]:
+                print("    " + x)
         print()
 
 
@@ -1114,10 +1127,7 @@ class Packages(Records, metaclass=Singleton):
     singular_class = Package
     groups = {}
     sub_commands = {
-        'usage': {
-            'required_args': 0,
-            'args_description': ''
-        },
+        "usage": {"required_args": 0, "args_description": ""},
     }
 
 
@@ -1142,19 +1152,19 @@ class PatchPolicy(Record):
 
     def set_version_update_during(self, pkg_version):
         change_made = False
-        cur_ver = self.data['general']['target_version']
+        cur_ver = self.data["general"]["target_version"]
 
         #######################################################################
         # If you don't delete the self_service_icon then it will error
         #   <Response [409]>: PUT - https://example.com:8443/JSSResource/patchpolicies/id/18:
         #   Conflict: Error: Problem with icon
         #   Couldn't save changed record: <Response [409]>
-        del(self.data['user_interaction']['self_service_icon'])
+        del self.data["user_interaction"]["self_service_icon"]
         #######################################################################
 
         if cur_ver != pkg_version:
             print(f"Set version to {pkg_version}")
-            self.data['general']['target_version'] = pkg_version
+            self.data["general"]["target_version"] = pkg_version
             change_made = True
         else:
             print(f"Version is already {pkg_version}")
@@ -1164,10 +1174,7 @@ class PatchPolicy(Record):
 class PatchPolicies(Records, metaclass=Singleton):
     singular_class = PatchPolicy
     sub_commands = {
-        'set_version': {
-            'required_args': 1,
-            'args_description': ''
-        },
+        "set_version": {"required_args": 1, "args_description": ""},
     }
 
 
@@ -1176,11 +1183,11 @@ class PatchSoftwareTitle(Record):
 
     def packages_print_during(self):
         print(self.name)
-        versions = self.data['versions']['version']
+        versions = self.data["versions"]["version"]
         if not type(versions) is list:
-            versions = [ versions ]
+            versions = [versions]
         for version in versions:
-            if version['package'] != None:
+            if version["package"] != None:
                 print(f" {version['software_version']}: {version['package']['name']}")
 
     def patchpolicies_print_during(self):
@@ -1190,62 +1197,64 @@ class PatchSoftwareTitle(Record):
             parent_id = policy.get_path("software_title_configuration_id")[0]
             if str(parent_id) != str(self.id):
                 continue
-            print(" "+str(policy))
+            print(" " + str(policy))
 
     def set_all_packages_update_during(self):
         policy_regex = {
-            '1Password 7': '^1Password-%VERSION%\.pkg',
-            'Apple GarageBand 10': '^GarageBand-%VERSION%\.pkg',
-            'Apple Keynote': '^Keynote-%VERSION%\.pkg',
-            'Apple Numbers': '^Numbers-%VERSION%\.pkg',
-            'Apple Pages': '^Pages-%VERSION%\.pkg',
-            'Apple Xcode': '^Xcode-%VERSION%\.pkg',
-            'Apple iMovie': '^iMovie-%VERSION%\.pkg',
-            'Arduino IDE': '^Arduino-%VERSION%\.pkg',
-            'Bare Bones BBEdit':'BBEdit-%VERSION%\.pkg',
-            'BusyCal 3': '^BusyCal-%VERSION%\.pkg',
-            'Microsoft Remote Desktop 10': '^Microsoft Remote Desktop-%VERSION%\.pkg',
-            'Microsoft Visual Studio Code': '^Visual Studio Code-%VERSION%\.pkg',
-            'Microsoft Teams': '^Microsoft_Teams_%VERSION%\.pkg',
-            'Mozilla Firefox': '^Firefox-%VERSION%\.pkg',
-            'R for Statistical Computing': '^R-%VERSION%\.pkg',
-            'RStudio Desktop': 'RStudio-%VERSION%\.dmg',
-            'Sublime Text 3': 'Sublime Text-%VERSION%\.pkg',
-            'VLC media player': 'VLC-%VERSION%\.pkg',
-            'VMware Fusion 12': 'VMware Fusion-%VERSION%\.pkg',
-            'VMware Horizon 8 Client': 'VMwareHorizonClient-%VERSION%.pkg',
-            'Zoom Client for Meetings': 'Zoom-%VERSION%.pkg',
+            "1Password 7": "^1Password-%VERSION%\.pkg",
+            "Apple GarageBand 10": "^GarageBand-%VERSION%\.pkg",
+            "Apple Keynote": "^Keynote-%VERSION%\.pkg",
+            "Apple Numbers": "^Numbers-%VERSION%\.pkg",
+            "Apple Pages": "^Pages-%VERSION%\.pkg",
+            "Apple Xcode": "^Xcode-%VERSION%\.pkg",
+            "Apple iMovie": "^iMovie-%VERSION%\.pkg",
+            "Arduino IDE": "^Arduino-%VERSION%\.pkg",
+            "Bare Bones BBEdit": "BBEdit-%VERSION%\.pkg",
+            "BusyCal 3": "^BusyCal-%VERSION%\.pkg",
+            "Microsoft Remote Desktop 10": "^Microsoft Remote Desktop-%VERSION%\.pkg",
+            "Microsoft Visual Studio Code": "^Visual Studio Code-%VERSION%\.pkg",
+            "Microsoft Teams": "^Microsoft_Teams_%VERSION%\.pkg",
+            "Mozilla Firefox": "^Firefox-%VERSION%\.pkg",
+            "R for Statistical Computing": "^R-%VERSION%\.pkg",
+            "RStudio Desktop": "RStudio-%VERSION%\.dmg",
+            "Sublime Text 3": "Sublime Text-%VERSION%\.pkg",
+            "VLC media player": "VLC-%VERSION%\.pkg",
+            "VMware Fusion 12": "VMware Fusion-%VERSION%\.pkg",
+            "VMware Horizon 8 Client": "VMwareHorizonClient-%VERSION%.pkg",
+            "Zoom Client for Meetings": "Zoom-%VERSION%.pkg",
         }
         change_made = False
         packages = jamf_records(Packages)
-        versions = self.data['versions']['version']
+        versions = self.data["versions"]["version"]
         if not type(versions) is list:
-            versions = [ versions ]
+            versions = [versions]
         for pkg_version in versions:
             for package in packages:
-                if not pkg_version['package']:
+                if not pkg_version["package"]:
                     if self.name in policy_regex:
                         regex = policy_regex[self.name]
-                        regex = regex.replace("%VERSION%",pkg_version['software_version'])
+                        regex = regex.replace(
+                            "%VERSION%", pkg_version["software_version"]
+                        )
                     else:
                         regex = f".*{self.name}.*{pkg_version['software_version']}\.pkg"
                     regex = regex.replace("(", "\\(")
                     regex = regex.replace(")", "\\)")
                     if re.search(regex, package.name):
                         print(f"Matched {package.name}")
-                        pkg_version['package'] = {'name':package.name}
+                        pkg_version["package"] = {"name": package.name}
                         change_made = True
         return change_made
 
     def set_package_for_version_update_during(self, package, target_version):
         change_made = False
-        versions = self.data['versions']['version']
+        versions = self.data["versions"]["version"]
         if not type(versions) is list:
-            versions = [ versions ]
+            versions = [versions]
         for pkg_version in versions:
-            if pkg_version['software_version'] == target_version:
+            if pkg_version["software_version"] == target_version:
                 print(f"{target_version}: {package}")
-                pkg_version['package'] = {'name':package}
+                pkg_version["package"] = {"name": package}
                 change_made = True
         return change_made
 
@@ -1253,22 +1262,10 @@ class PatchSoftwareTitle(Record):
 class PatchSoftwareTitles(Records, metaclass=Singleton):
     singular_class = PatchSoftwareTitle
     sub_commands = {
-        'patchpolicies': {
-            'required_args': 0,
-            'args_description': ''
-        },
-        'packages': {
-            'required_args': 0,
-            'args_description': ''
-        },
-        'set_package_for_version': {
-            'required_args': 2,
-            'args_description': ''
-        },
-        'set_all_packages': {
-            'required_args': 0,
-            'args_description': ''
-        },
+        "patchpolicies": {"required_args": 0, "args_description": ""},
+        "packages": {"required_args": 0, "args_description": ""},
+        "set_package_for_version": {"required_args": 2, "args_description": ""},
+        "set_all_packages": {"required_args": 0, "args_description": ""},
     }
 
 
@@ -1306,68 +1303,72 @@ class Policy(Record):
 
         # Trigger
         _trigger = []
-        if self.data['general']['trigger_other']:
+        if self.data["general"]["trigger_other"]:
             _trigger.append(f"{self.data['general']['trigger_other']}")
-        if self.data['general']['trigger_enrollment_complete'] == "true":
+        if self.data["general"]["trigger_enrollment_complete"] == "true":
             _trigger.append("Enrollment")
-        if self.data['general']['trigger_startup'] == "true":
+        if self.data["general"]["trigger_startup"] == "true":
             _trigger.append("Startup")
-        if self.data['general']['trigger_login'] == "true":
+        if self.data["general"]["trigger_login"] == "true":
             _trigger.append("Login")
-        if self.data['general']['trigger_logout'] == "true":
+        if self.data["general"]["trigger_logout"] == "true":
             _trigger.append("Logout")
-        if self.data['general']['trigger_network_state_changed'] == "true":
+        if self.data["general"]["trigger_network_state_changed"] == "true":
             _trigger.append("Network")
-        if self.data['general']['trigger_checkin'] == "true":
+        if self.data["general"]["trigger_checkin"] == "true":
             _trigger.append("Checkin")
         _text += ", ".join(_trigger)
         _text += "\t"
 
         # Scope
         _scope = []
-        if self.data['scope']['all_computers'] == 'true':
+        if self.data["scope"]["all_computers"] == "true":
             _scope.append("all_computers")
-        if self.data['scope']['buildings']:
-            for a in self.force_array(self.data['scope']['buildings'], 'building'):
-                _scope.append(a['name'])
-        if self.data['scope']['computer_groups']:
-            for a in self.force_array(self.data['scope']['computer_groups'], 'computer_group'):
-                _scope.append(a['name'])
-        if self.data['scope']['computers']:
-            for a in self.force_array(self.data['scope']['computers'], 'computer'):
-                _scope.append(a['name'])
-        if self.data['scope']['departments']:
-            for a in self.force_array(self.data['scope']['departments'], 'department'):
-                _scope.append(a['name'])
-        if self.data['scope']['limit_to_users']['user_groups']:
+        if self.data["scope"]["buildings"]:
+            for a in self.force_array(self.data["scope"]["buildings"], "building"):
+                _scope.append(a["name"])
+        if self.data["scope"]["computer_groups"]:
+            for a in self.force_array(
+                self.data["scope"]["computer_groups"], "computer_group"
+            ):
+                _scope.append(a["name"])
+        if self.data["scope"]["computers"]:
+            for a in self.force_array(self.data["scope"]["computers"], "computer"):
+                _scope.append(a["name"])
+        if self.data["scope"]["departments"]:
+            for a in self.force_array(self.data["scope"]["departments"], "department"):
+                _scope.append(a["name"])
+        if self.data["scope"]["limit_to_users"]["user_groups"]:
             _scope.append("limit_to_users")
         _text += ", ".join(_scope)
         _text += "\t"
 
         # Packages
-        if self.data['package_configuration']['packages']['size'] != '0':
-            for a in self.force_array(self.data['package_configuration']['packages'], 'package'):
-                _text +=  a['name']
+        if self.data["package_configuration"]["packages"]["size"] != "0":
+            for a in self.force_array(
+                self.data["package_configuration"]["packages"], "package"
+            ):
+                _text += a["name"]
         _text += "\t"
 
         # Printers
-        if self.data['printers']['size'] != '0':
-            for a in self.force_array(self.data['printers'], 'printer'):
-                _text +=  a['name']
+        if self.data["printers"]["size"] != "0":
+            for a in self.force_array(self.data["printers"], "printer"):
+                _text += a["name"]
 
-            _text += self.data['printers']['size']
+            _text += self.data["printers"]["size"]
         _text += "\t"
 
         # Scripts
-        if self.data['scripts']['size'] != '0':
-            for a in self.force_array(self.data['scripts'], 'script'):
-                _text +=  a['name']
+        if self.data["scripts"]["size"] != "0":
+            for a in self.force_array(self.data["scripts"], "script"):
+                _text += a["name"]
         _text += "\t"
 
         # Self Service
         _self_service = []
-        if self.data['self_service']['use_for_self_service'] != 'false':
-            _self_service.append('Yes')
+        if self.data["self_service"]["use_for_self_service"] != "false":
+            _self_service.append("Yes")
         if len(_self_service) > 0:
             _text += ", ".join(_self_service)
         _text += "\t"
@@ -1375,94 +1376,91 @@ class Policy(Record):
         ###############
 
         # Account Maintenance
-        if self.data['account_maintenance']['accounts']['size'] != '0':
-            for a in self.force_array(self.data['account_maintenance']['accounts'], 'account'):
-                _text +=  a['username']
+        if self.data["account_maintenance"]["accounts"]["size"] != "0":
+            for a in self.force_array(
+                self.data["account_maintenance"]["accounts"], "account"
+            ):
+                _text += a["username"]
         _text += "\t"
 
         # Disk Encryption
-        if self.data['disk_encryption']['action'] != 'none':
-            _text += self.data['disk_encryption']['action']
+        if self.data["disk_encryption"]["action"] != "none":
+            _text += self.data["disk_encryption"]["action"]
         _text += "\t"
 
         # Dock Items
-        if self.data['dock_items']['size'] != '0':
-            _text += self.data['dock_items']['size']
+        if self.data["dock_items"]["size"] != "0":
+            _text += self.data["dock_items"]["size"]
         _text += "\t"
 
         return _text
 
     def promote_update_during(self):
-        if not 'package' in self.data['package_configuration']['packages']:
+        if not "package" in self.data["package_configuration"]["packages"]:
             print(f"{self.name} has no package to update.")
             return True
-        if int(self.data['package_configuration']['packages']['size']) > 1:
-            my_packages = self.data['package_configuration']['packages']['package']
+        if int(self.data["package_configuration"]["packages"]["size"]) > 1:
+            my_packages = self.data["package_configuration"]["packages"]["package"]
         else:
-            my_packages = [self.data['package_configuration']['packages']['package']]
+            my_packages = [self.data["package_configuration"]["packages"]["package"]]
 
         all_packages = jamf_records(Packages)
         print(self.name)
         made_change = False
         for my_package in my_packages:
             similar_packages = []
-            search_str = re.sub('-.*', '', my_package['name'])
+            search_str = re.sub("-.*", "", my_package["name"])
             for package in all_packages:
                 if package.name.find(search_str) == 0:
                     similar_packages.append(package.name)
             if len(similar_packages) > 1:
                 index = 1
                 for similar_package in reversed(similar_packages):
-                    if similar_package == my_package['name']:
+                    if similar_package == my_package["name"]:
                         print(f"  {index}. {similar_package} [Current]")
                     else:
                         print(f"  {index}. {similar_package}")
                     index += 1
                 answer = "0"
                 choices = list(map(str, range(1, index)))
-                choices.append('')
+                choices.append("")
                 while answer not in choices:
                     answer = input("Choose a package [return skips]: ")
-                if answer == '':
+                if answer == "":
                     return True
-                answer = len(similar_packages)-int(answer)
-                my_package['name'] = similar_packages[answer]
-                del my_package['id']
+                answer = len(similar_packages) - int(answer)
+                my_package["name"] = similar_packages[answer]
+                del my_package["id"]
                 made_change = True
         if made_change:
-            pprint(self.data['package_configuration']['packages'])
+            pprint(self.data["package_configuration"]["packages"])
             self.save()
 
 
 class Policies(Records, metaclass=Singleton):
     singular_class = Policy
     sub_commands = {
-        'promote': {
-            'required_args': 0,
-            'args_description': ''
-        },
-        'spreadsheet': {
-            'required_args': 0,
-            'args_description': ''
-        },
+        "promote": {"required_args": 0, "args_description": ""},
+        "spreadsheet": {"required_args": 0, "args_description": ""},
     }
 
     def spreadsheet_print_before(self):
         header = [
-            'Name',
-            'Category',
-            'Frequency',
-            'Trigger',
-            'Scope',
-            'Packages',
-            'Printers',
-            'Scripts',
-            'Self Service',
-            'Account Maintenance',
-            'Disk Encryption',
-            'Dock Items',
+            "Name",
+            "Category",
+            "Frequency",
+            "Trigger",
+            "Scope",
+            "Packages",
+            "Printers",
+            "Scripts",
+            "Self Service",
+            "Account Maintenance",
+            "Disk Encryption",
+            "Dock Items",
         ]
         print("\t".join(header))
+
 
 class Printer(Record):
     plural_class = "Printers"
@@ -1494,10 +1492,7 @@ class Scripts(Records, metaclass=Singleton):
     # http://localhost/view/settings/computer/scripts
     singular_class = Script
     sub_commands = {
-        'script_contents': {
-            'required_args': 0,
-            'args_description': ''
-        },
+        "script_contents": {"required_args": 0, "args_description": ""},
     }
 
 
@@ -1576,7 +1571,7 @@ class WebHooks(Records, metaclass=Singleton):
     singular_class = WebHook
 
 
-def jamf_records(cls, name='', exclude=()):
+def jamf_records(cls, name="", exclude=()):
     """
     Get Jamf Records
 
@@ -1591,7 +1586,8 @@ def jamf_records(cls, name='', exclude=()):
     # NOTE: empty string ('') always in all other strings
     return [c for c in included if name in c.name]
 
-def categories(name='', exclude=()):
+
+def categories(name="", exclude=()):
     """
     Get Jamf Categories
 

--- a/jamf/setconfig.py
+++ b/jamf/setconfig.py
@@ -5,10 +5,10 @@
 Jamf Config
 """
 
-__author__ = 'Sam Forester'
-__email__ = 'sam.forester@utah.edu'
-__copyright__ = 'Copyright (c) 2020 University of Utah, Marriott Library'
-__license__ = 'MIT'
+__author__ = "Sam Forester"
+__email__ = "sam.forester@utah.edu"
+__copyright__ = "Copyright (c) 2020 University of Utah, Marriott Library"
+__license__ = "MIT"
 __version__ = "1.0.4"
 
 
@@ -21,6 +21,7 @@ import pprint
 import sys
 from os import path
 
+
 class Parser:
     def __init__(self):
         myplatform = platform.system()
@@ -30,34 +31,34 @@ class Parser:
             default_pref = jamf.config.LINUX_PREFS_TILDA
         self.parser = argparse.ArgumentParser()
         self.parser.add_argument(
-            '-H',
-            '--hostname',
-            help='specify hostname (default: prompt)')
+            "-H", "--hostname", help="specify hostname (default: prompt)"
+        )
         self.parser.add_argument(
-            '-u',
-            '--user',
-            help='specify username (default: prompt)')
+            "-u", "--user", help="specify username (default: prompt)"
+        )
         self.parser.add_argument(
-            '-p',
-            '--passwd',
-            help='specify password (default: prompt)')
+            "-p", "--passwd", help="specify password (default: prompt)"
+        )
         self.parser.add_argument(
-            '-C',
-            '--config',
-            dest='path',
-            metavar='PATH',
+            "-C",
+            "--config",
+            dest="path",
+            metavar="PATH",
             default=default_pref,
-            help=f"specify config file (default {default_pref})")
+            help=f"specify config file (default {default_pref})",
+        )
         self.parser.add_argument(
-            '-P',
-            '--print',
-            action='store_true',
-            help='print existing config profile (except password!)')
+            "-P",
+            "--print",
+            action="store_true",
+            help="print existing config profile (except password!)",
+        )
         self.parser.add_argument(
-            '-t',
-            '--test',
-            action='store_true',
-            help='Connect to the Jamf server using the config file')
+            "-t",
+            "--test",
+            action="store_true",
+            help="Connect to the Jamf server using the config file",
+        )
 
     def parse(self, argv):
         """
@@ -80,13 +81,13 @@ def setconfig(argv):
         elif myplatform == "Linux":
             default_pref = jamf.config.LINUX_PREFS_TILDA
         config_path = default_pref
-    if config_path[0] == '~':
+    if config_path[0] == "~":
         config_path = path.expanduser(config_path)
     if args.test:
         api = jamf.API(config_path=config_path)
-        pprint.pprint(api.get('accounts'))
+        pprint.pprint(api.get("accounts"))
     elif args.print:
-        conf = jamf.config.Config(prompt=False,explain=True,config_path=config_path)
+        conf = jamf.config.Config(prompt=False, explain=True, config_path=config_path)
         print(conf.hostname)
         print(conf.username)
         if conf.password:
@@ -107,10 +108,7 @@ def setconfig(argv):
         else:
             passwd = getpass.getpass()
         conf = jamf.config.Config(
-            hostname=hostname,
-            username=user,
-            password=passwd,
-            prompt=False
+            hostname=hostname, username=user, password=passwd, prompt=False
         )
         conf.save(config_path=config_path)
 

--- a/jamf/version.py
+++ b/jamf/version.py
@@ -7,10 +7,8 @@
 import os
 import re
 
-__all__ = (
-    'string',
-    'jamf_version_up_to'
-)
+__all__ = ("string", "jamf_version_up_to")
+
 
 def string():
     try:
@@ -29,8 +27,8 @@ def jamf_version_up_to(min_version):
         m = re.match(r"^([0-9]+\.[0-9]+\.[0-9]+)", full_version)
         min1 = tuple(map(int, (min_version.split("."))))
         cur = tuple(map(int, (m.group(1).split("."))))
-        if (min1 <= cur):
-            return min_version # Pass
+        if min1 <= cur:
+            return min_version  # Pass
     except AttributeError:
-        return full_version # Fail
-    return full_version # Fail
+        return full_version  # Fail
+    return full_version  # Fail

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ jamf_version = (
     .stdout.decode("utf-8")
     .strip()
 )
-#assert "." in jamf_version
+# assert "." in jamf_version
 
 assert os.path.isfile("jamf/version.py")
 with open("jamf/VERSION", "w", encoding="utf-8") as fh:
@@ -22,16 +22,14 @@ setuptools.setup(
     author="The University of Utah",
     author_email="mlib-its-mac@lists.utah.edu",
     description="Python wrapper for Jamf Pro API",
-    license='MIT',
+    license="MIT",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/univ-of-utah-marriott-library-apple/python-jamf",
     packages=setuptools.find_packages(),
-    package_data={'jamf': ['*.json', 'VERSION']},
+    package_data={"jamf": ["*.json", "VERSION"]},
     include_package_data=True,
-    entry_points={
-        'console_scripts': ['conf-python-jamf=jamf.setconfig:main']
-    },
+    entry_points={"console_scripts": ["conf-python-jamf=jamf.setconfig:main"]},
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",
@@ -40,6 +38,6 @@ setuptools.setup(
         # 5 - Production/Stable
         "Development Status :: 4 - Beta",
     ],
-    python_requires='>=3.6',
-    install_requires=['requests>=2.24.0','keyring>=23.0.0'],
+    python_requires=">=3.6",
+    install_requires=["requests>=2.24.0", "keyring>=23.0.0"],
 )

--- a/tests/api_mock_test.py
+++ b/tests/api_mock_test.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
-#pylint: disable=relative-beyond-top-level, too-few-public-methods, unused-argument
-#pylint: disable=missing-class-docstring, missing-function-docstring
+# pylint: disable=relative-beyond-top-level, too-few-public-methods, unused-argument
+# pylint: disable=missing-class-docstring, missing-function-docstring
 """
 Tests for JSS API
 """
 
-__author__ = 'Sam Forester'
-__email__ = 'sam.forester@utah.edu'
-__copyright__ = 'Copyright (c) 2020 University of Utah, Marriott Library'
-__license__ = 'MIT'
+__author__ = "Sam Forester"
+__email__ = "sam.forester@utah.edu"
+__copyright__ = "Copyright (c) 2020 University of Utah, Marriott Library"
+__license__ = "MIT"
 __version__ = "0.0.0"
 
 import unittest
@@ -18,27 +18,26 @@ from jamf import api
 
 
 class MockResponse:
-
     def __init__(self, data, path=None):
         class MockRequest:
             pass
+
         self.request = MockRequest()
-        self.return_code = data['code']
-        self.request.method = data.get('method', 'GET')
-        self.url = data.get('url', 'http://mock.url')
+        self.return_code = data["code"]
+        self.request.method = data.get("method", "GET")
+        self.url = data.get("url", "http://mock.url")
         if path:
-            with open(path, 'rb') as fptr:
+            with open(path, "rb") as fptr:
                 self.text = fptr.read()
         else:
-            self.text = data.get('text', '')
+            self.text = data.get("text", "")
 
     @property
-    def ok(self): #pylint: disable=invalid-name
+    def ok(self):  # pylint: disable=invalid-name
         return 200 <= self.return_code <= 400
 
 
 class MockSession:
-
     def __init__(self, response=None):
         self.headers = {}
         self.response = response
@@ -61,45 +60,43 @@ class BaseTestCase(unittest.TestCase):
 
 
 class TestAPI(unittest.TestCase):
-
     def setUp(self):
-        response = MockResponse({'text': '<>', 'code': 200})
+        response = MockResponse({"text": "<>", "code": 200})
         self.api = api.API()
         self.api.session = MockSession(response)
 
 
-UNAUTHORIZED = ('<html>\n'
-                '<head>\n'
-                '<title>Status page</title>\n'
-                '</head>\n'
-                '<body style="font-family: sans-serif;">\n'
-                '<p style="font-size: 1.2em;font-weight: bold;margin: 1em '
-                '0px;">Unauthorized</p>\n'
-                '<p>The request requires user authentication</p>\n'
-                '<p>You can get technical details '
-                '<a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.'
-                'html#sec10.4.2">here</a>.<br>\n'
-                'Please continue your visit at our '
-                '<a href="/">home page</a>.\n'
-                '</p>\n'
-                '</body>\n'
-                '</html>\n')
+UNAUTHORIZED = (
+    "<html>\n"
+    "<head>\n"
+    "<title>Status page</title>\n"
+    "</head>\n"
+    '<body style="font-family: sans-serif;">\n'
+    '<p style="font-size: 1.2em;font-weight: bold;margin: 1em '
+    '0px;">Unauthorized</p>\n'
+    "<p>The request requires user authentication</p>\n"
+    "<p>You can get technical details "
+    '<a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.'
+    'html#sec10.4.2">here</a>.<br>\n'
+    "Please continue your visit at our "
+    '<a href="/">home page</a>.\n'
+    "</p>\n"
+    "</body>\n"
+    "</html>\n"
+)
 
 
 class TestAPIError(unittest.TestCase):
-
     def setUp(self):
         self.html = UNAUTHORIZED
-        self.response = MockResponse({'text': self.html,
-                                      'code': 401,
-                                      'method': 'GET'})
+        self.response = MockResponse({"text": self.html, "code": 401, "method": "GET"})
 
     def test_empty_response_text(self):
         """
         Test APIError still works if response.text == ''
         """
-        expected = 'failed'
-        self.response.text = ''
+        expected = "failed"
+        self.response.text = ""
         err = api.APIError(self.response)
         result = err.message
         self.assertEqual(expected, result)
@@ -110,7 +107,7 @@ class TestAPIError(unittest.TestCase):
         """
         Test APIError still works if response.text == None
         """
-        expected = 'failed'
+        expected = "failed"
         self.response.text = None
         err = api.APIError(self.response)
         result = err.message
@@ -140,17 +137,16 @@ class TestAPIError(unittest.TestCase):
         """
         err = api.APIError(self.response)
         with self.assertRaises(AttributeError):
-            unused = err.undefined_attribute #pylint: disable=unused-variable
+            unused = err.undefined_attribute  # pylint: disable=unused-variable
 
 
 class TestParseError(unittest.TestCase):
-
     def test_parse_empty_string(self):
         """
         test parse_html_error return empty list on ''
         """
         expected = []
-        result = api.parse_html_error('')
+        result = api.parse_html_error("")
         self.assertEqual(expected, result)
 
     def test_parse_none(self):
@@ -165,34 +161,33 @@ class TestParseError(unittest.TestCase):
         """
         test parse_html_error parses results
         """
-        expected = ['Unauthorized', 'The request requires user authentication']
+        expected = ["Unauthorized", "The request requires user authentication"]
         result = api.parse_html_error(UNAUTHORIZED)
         self.assertEqual(expected, result)
 
 
 class TestJSSErrorParser(unittest.TestCase):
-
     def test_parse_unauthorized(self):
         """
         test parse_html_error parses results
         """
-        expected = ['Unauthorized', 'The request requires user authentication']
+        expected = ["Unauthorized", "The request requires user authentication"]
         parsed = api.JSSErrorParser(UNAUTHORIZED)
-        result = [t.text for t in parsed.find_all('p')][0:2]
+        result = [t.text for t in parsed.find_all("p")][0:2]
         self.assertEqual(expected, result)
 
     def test_parse_empty_string(self):
         expected = []
-        result = api.JSSErrorParser('').find_all('p')
+        result = api.JSSErrorParser("").find_all("p")
         self.assertEqual(expected, result)
 
     def test_parse_none(self):
         expected = []
-        result = api.JSSErrorParser(None).find_all('p')
+        result = api.JSSErrorParser(None).find_all("p")
         self.assertEqual(expected, result)
 
 
-if __name__ == '__main__':
-    FMT = '%(asctime)s: %(levelname)8s: %(name)s - %(funcName)s(): %(message)s'
+if __name__ == "__main__":
+    FMT = "%(asctime)s: %(levelname)8s: %(name)s - %(funcName)s(): %(message)s"
     logging.basicConfig(level=logging.DEBUG, format=FMT)
     unittest.main(verbosity=1)

--- a/tests/convert_json_xml_test.py
+++ b/tests/convert_json_xml_test.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
-#pylint: disable=relative-beyond-top-level, too-few-public-methods, unused-argument
-#pylint: disable=missing-class-docstring, missing-module-docstring, invalid-name
+# pylint: disable=relative-beyond-top-level, too-few-public-methods, unused-argument
+# pylint: disable=missing-class-docstring, missing-module-docstring, invalid-name
 
 import unittest
 from jamf import convert
 
-patchpolicies = '''<?xml version="1.0" encoding="UTF-8"?>
+patchpolicies = """<?xml version="1.0" encoding="UTF-8"?>
 <patch_available_titles>
   <size>47</size>
   <available_titles>
@@ -340,14 +340,13 @@ patchpolicies = '''<?xml version="1.0" encoding="UTF-8"?>
     </available_title>
   </available_titles>
 </patch_available_titles>
-'''
+"""
 
 
 class ConversionTest(unittest.TestCase):
-
     def setUp(self):
-        self.xml = '<nothing/>'
-        self.data = {'nothing': None}
+        self.xml = "<nothing/>"
+        self.data = {"nothing": None}
 
     def test_xml_to_dict(self):
         """
@@ -385,43 +384,50 @@ class ConversionTest(unittest.TestCase):
 
 
 class TestSimpleDict(ConversionTest):
-
     def setUp(self):
-        self.xml = '<test><key>value</key></test>'
-        self.data = {'test': {'key': 'value'}}
+        self.xml = "<test><key>value</key></test>"
+        self.data = {"test": {"key": "value"}}
 
 
 class TestSimpleList(ConversionTest):
-
     def setUp(self):
-        self.xml = ('<list>'
-                    '<item>one</item>'
-                    '<item>two</item>'
-                    '<item>three</item>'
-                    '</list>')
-        self.data = {'list': {'item': ['one', 'two', 'three']}}
+        self.xml = (
+            "<list>"
+            "<item>one</item>"
+            "<item>two</item>"
+            "<item>three</item>"
+            "</list>"
+        )
+        self.data = {"list": {"item": ["one", "two", "three"]}}
 
 
 class TestListOfDicts(ConversionTest):
-
     def setUp(self):
-        self.xml = ('<list>'
-                    '<item>'
-                    '<id>1</id>'
-                    '<name>one</name>'
-                    '</item>'
-                    '<item>'
-                    '<id>2</id>'
-                    '<name>two</name>'
-                    '</item>'
-                    '<item>'
-                    '<id>3</id>'
-                    '<name>three</name>'
-                    '</item>'
-                    '</list>')
-        self.data = {'list': {'item': [{'id': '1', 'name': 'one'},
-                                       {'id': '2', 'name': 'two'},
-                                       {'id': '3', 'name': 'three'}]}}
+        self.xml = (
+            "<list>"
+            "<item>"
+            "<id>1</id>"
+            "<name>one</name>"
+            "</item>"
+            "<item>"
+            "<id>2</id>"
+            "<name>two</name>"
+            "</item>"
+            "<item>"
+            "<id>3</id>"
+            "<name>three</name>"
+            "</item>"
+            "</list>"
+        )
+        self.data = {
+            "list": {
+                "item": [
+                    {"id": "1", "name": "one"},
+                    {"id": "2", "name": "two"},
+                    {"id": "3", "name": "three"},
+                ]
+            }
+        }
 
 
 @unittest.skip
@@ -433,108 +439,110 @@ class TestPatchSoftwareTitle(ConversionTest):
     from a dictionary to xml string, so even though the values are identical,
     string comparison fails
     """
+
     def setUp(self):
         self.maxDiff = None
-        self.xml = ('<patch_software_title>'
-                    '<id>31</id>'
-                    '<name>Mozilla Firefox</name>'
-                    '<name_id>MozillaFirefox</name_id>'
-                    '<source_id>2</source_id>'
-                    '<notifications>'
-                    '<email_notification>true</email_notification>'
-                    '<web_notification>true</web_notification>'
-                    '</notifications>'
-                    '<category>'
-                    '<id>1</id>'
-                    '<name>Apps - Web Browsers</name>'
-                    '</category>'
-                    '<site>'
-                    '<id>-1</id>'
-                    '<name>None</name>'
-                    '</site>'
-                    '<versions>'
-                    '<version>'
-                    '<software_version>69.0.1</software_version>'
-                    '<package>'
-                    '<id>284</id>'
-                    '<name>firefox_69.0.1_2019.09.18_rcg.pkg</name>'
-                    '</package>'
-                    '</version>'
-                    '<version>'
-                    '<software_version>69.0</software_version>'
-                    '<package>'
-                    '<id>253</id>'
-                    '<name>firefox_69.0_2019.09.04_rcg.pkg</name>'
-                    '</package>'
-                    '</version>'
-                    '<version>'
-                    '<software_version>68.0.2</software_version>'
-                    '<package>'
-                    '<id>182</id>'
-                    '<name>firefox_68.0.2_2019.08.20_rcg.pkg</name>'
-                    '</package>'
-                    '</version>'
-                    '<version>'
-                    '<software_version>68.0.1</software_version>'
-                    '<package>'
-                    '<id>121</id>'
-                    '<name>firefox_68.0.1_2019.07.22_rcg.pkg</name>'
-                    '</package>'
-                    '</version>'
-                    '</versions>'
-                    '</patch_software_title>')
+        self.xml = (
+            "<patch_software_title>"
+            "<id>31</id>"
+            "<name>Mozilla Firefox</name>"
+            "<name_id>MozillaFirefox</name_id>"
+            "<source_id>2</source_id>"
+            "<notifications>"
+            "<email_notification>true</email_notification>"
+            "<web_notification>true</web_notification>"
+            "</notifications>"
+            "<category>"
+            "<id>1</id>"
+            "<name>Apps - Web Browsers</name>"
+            "</category>"
+            "<site>"
+            "<id>-1</id>"
+            "<name>None</name>"
+            "</site>"
+            "<versions>"
+            "<version>"
+            "<software_version>69.0.1</software_version>"
+            "<package>"
+            "<id>284</id>"
+            "<name>firefox_69.0.1_2019.09.18_rcg.pkg</name>"
+            "</package>"
+            "</version>"
+            "<version>"
+            "<software_version>69.0</software_version>"
+            "<package>"
+            "<id>253</id>"
+            "<name>firefox_69.0_2019.09.04_rcg.pkg</name>"
+            "</package>"
+            "</version>"
+            "<version>"
+            "<software_version>68.0.2</software_version>"
+            "<package>"
+            "<id>182</id>"
+            "<name>firefox_68.0.2_2019.08.20_rcg.pkg</name>"
+            "</package>"
+            "</version>"
+            "<version>"
+            "<software_version>68.0.1</software_version>"
+            "<package>"
+            "<id>121</id>"
+            "<name>firefox_68.0.1_2019.07.22_rcg.pkg</name>"
+            "</package>"
+            "</version>"
+            "</versions>"
+            "</patch_software_title>"
+        )
         self.data = {
-            'patch_software_title': {
-                'category': {
-                    'id': '1',
-                    'name': 'Apps - Web Browsers'
+            "patch_software_title": {
+                "category": {"id": "1", "name": "Apps - Web Browsers"},
+                "id": "31",
+                "name": "Mozilla Firefox",
+                "name_id": "MozillaFirefox",
+                "notifications": {
+                    "email_notification": "true",
+                    "web_notification": "true",
                 },
-                'id': '31',
-                'name': 'Mozilla Firefox',
-                'name_id': 'MozillaFirefox',
-                'notifications': {
-                    'email_notification': 'true',
-                    'web_notification': 'true'
-                },
-                'site': {
-                    'id': '-1',
-                    'name': 'None'
-                },
-                'source_id': '2',
-                'versions': {
-                    'version': [
+                "site": {"id": "-1", "name": "None"},
+                "source_id": "2",
+                "versions": {
+                    "version": [
                         {
-                            'package': {
-                                'id': '284',
-                                'name': 'firefox_69.0.1_2019.09.18_rcg.pkg'
+                            "package": {
+                                "id": "284",
+                                "name": "firefox_69.0.1_2019.09.18_rcg.pkg",
                             },
-                            'software_version': '69.0.1'
+                            "software_version": "69.0.1",
                         },
                         {
-                            'package': {
-                                'id': '253',
-                                'name': 'firefox_69.0_2019.09.04_rcg.pkg'
+                            "package": {
+                                "id": "253",
+                                "name": "firefox_69.0_2019.09.04_rcg.pkg",
                             },
-                            'software_version': '69.0'
+                            "software_version": "69.0",
                         },
                         {
-                            'package': {
-                                'id': '182',
-                                'name': 'firefox_68.0.2_2019.08.20_rcg.pkg'
+                            "package": {
+                                "id": "182",
+                                "name": "firefox_68.0.2_2019.08.20_rcg.pkg",
                             },
-                            'software_version': '68.0.2'
+                            "software_version": "68.0.2",
                         },
                         {
-                            'package': {
-                                'id': '121',
-                                'name': 'firefox_68.0.1_2019.07.22_rcg.pkg'
+                            "package": {
+                                "id": "121",
+                                "name": "firefox_68.0.1_2019.07.22_rcg.pkg",
                             },
-                            'software_version': '68.0.1'}]}}}
+                            "software_version": "68.0.1",
+                        },
+                    ]
+                },
+            }
+        }
 
     @unittest.skip("key ordering causes incorrect failure")
     def test_dict_to_xml(self):
         pass
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main(verbosity=1)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,10 +4,10 @@
 tests for jamf.config
 """
 
-__author__ = 'Sam Forester'
-__email__ = 'sam.forester@utah.edu'
-__copyright__ = 'Copyright (c) 2020 University of Utah, Marriott Library'
-__license__ = 'MIT'
+__author__ = "Sam Forester"
+__email__ = "sam.forester@utah.edu"
+__copyright__ = "Copyright (c) 2020 University of Utah, Marriott Library"
+__license__ = "MIT"
 __version__ = "0.1.1"
 
 import copy
@@ -22,11 +22,12 @@ from jamf import config
 
 # temporary files created with tests
 LOCATION = pathlib.Path(__file__).parent
-TMPDIR = LOCATION / 'tmp' / 'config'
+TMPDIR = LOCATION / "tmp" / "config"
 # DATA = LOCATION / 'data' / 'config'
 
 DEFAULT_PREFERENCES = config.PREFERENCES
-PREFERENCES = TMPDIR / 'jamf.config.test.plist'
+PREFERENCES = TMPDIR / "jamf.config.test.plist"
+
 
 def setUpModule():
     """
@@ -46,6 +47,7 @@ class ConfigPathTests(unittest.TestCase):
     """
     config.PREFERENCES and path keyword argument tests
     """
+
     @classmethod
     def setUpClass(cls):
         """
@@ -63,7 +65,7 @@ class ConfigPathTests(unittest.TestCase):
         config.PREFERENCES = cls._saved_prefs
 
     def setUp(self):
-        self.altpath = pathlib.Path('/tmp/jamf.config.test.alt.plist').resolve()
+        self.altpath = pathlib.Path("/tmp/jamf.config.test.alt.plist").resolve()
 
     def tearDown(self):
         """
@@ -123,6 +125,7 @@ class BaseTestCase(unittest.TestCase):
     """
     Generic TestCase
     """
+
     @classmethod
     def setUpClass(cls):
         """
@@ -163,33 +166,31 @@ class BaseTestCase(unittest.TestCase):
 
 
 class ConfigTestCase(unittest.TestCase):
-
     def setUp(self):
-        self.path = TMPDIR / 'jamf.config.test.plist'
+        self.path = TMPDIR / "jamf.config.test.plist"
         self.config = config.Config(path=self.path)
 
     def test_load_attribute(self):
-        self.assertTrue(hasattr(self.config, 'load'))
+        self.assertTrue(hasattr(self.config, "load"))
 
     def test_save_attribute(self):
-        self.assertTrue(hasattr(self.config, 'save'))
+        self.assertTrue(hasattr(self.config, "save"))
 
     def test_get_attribute(self):
-        self.assertTrue(hasattr(self.config, 'get'))
+        self.assertTrue(hasattr(self.config, "get"))
 
     def test_set_attribute(self):
-        self.assertTrue(hasattr(self.config, 'set'))
+        self.assertTrue(hasattr(self.config, "set"))
 
     def test_remove_attribute(self):
-        self.assertTrue(hasattr(self.config, 'remove'))
+        self.assertTrue(hasattr(self.config, "remove"))
 
     def test_reset_attribute(self):
-        self.assertTrue(hasattr(self.config, 'reset'))
+        self.assertTrue(hasattr(self.config, "reset"))
 
 
 # @unittest.skip
 class TestNewConfig(BaseTestCase):
-
     @classmethod
     def setUpClass(cls):
         """
@@ -226,16 +227,16 @@ class TestNewConfig(BaseTestCase):
         """
         test modifying config does not create file
         """
-        self.config.set('test', 'value')
+        self.config.set("test", "value")
         self.assertNoFile(self.config.path)
 
     def test_set_and_get_string(self):
         """
         test set and get key/value pair as {'string': 'string'}
         """
-        expected = 'string'
-        self.config.set('string', expected)
-        result = self.config.get('string')
+        expected = "string"
+        self.config.set("string", expected)
+        result = self.config.get("string")
         self.assertEqual(expected, result)
 
     def test_set_and_get_date(self):
@@ -243,8 +244,8 @@ class TestNewConfig(BaseTestCase):
         test set and get key/value pair as {'date': dt.datetime.now()}
         """
         expected = dt.datetime.now()
-        self.config.set('date', expected)
-        result = self.config.get('date')
+        self.config.set("date", expected)
+        result = self.config.get("date")
         self.assertEqual(expected, result)
 
     def test_set_and_get_bool_true(self):
@@ -252,8 +253,8 @@ class TestNewConfig(BaseTestCase):
         test set and get key/value pair as {'true': False}
         """
         expected = True
-        self.config.set('true', expected)
-        result = self.config.get('true')
+        self.config.set("true", expected)
+        result = self.config.get("true")
         self.assertEqual(expected, result)
 
     def test_set_and_get_bool_false(self):
@@ -261,8 +262,8 @@ class TestNewConfig(BaseTestCase):
         test set and get key/value pair as {'false': False}
         """
         expected = False
-        self.config.set('false', expected)
-        result = self.config.get('false')
+        self.config.set("false", expected)
+        result = self.config.get("false")
         self.assertEqual(expected, result)
 
     def test_set_None(self):
@@ -270,36 +271,36 @@ class TestNewConfig(BaseTestCase):
         test set value as None raises ValueError
         """
         with self.assertRaises(ValueError):
-            self.config.set('test', None)
+            self.config.set("test", None)
 
     def test_get_missing(self):
         """
         test get missing key raises KeyError
         """
         with self.assertRaises(KeyError):
-            self.config.get('missing')
+            self.config.get("missing")
 
 
 class TestSaveConfig(BaseTestCase):
-
     def setUp(self):
         super().setUp()
         if self.config.path.exists():
             self.config.path.unlink()
-        self.data = {'string': 'string',
-                     'integer': 1,
-                     'true': True,
-                     'false': False,
-                     'date': dt.datetime(2020, 1, 13, 13, 13, 13),
-                     'dict': {'key': 'value', 'one': 1},
-                     'list': [1, 2, 3],
-                     'data': b'binary-data',
-                     'float': 0.01,
-                     'nesteddict': {'d1': {'key': 'value'},
-                                    'd2': {'key': 'value2'}},
-                     'nestedlist': [[1, 2, 3], [4, 5, 6]],
-                     'dictoflists': {'one': [1, 2, 3], 'two': [4, 5, 6]},
-                     'listofdicts': [{'one': 1}, {'two': 2}]}
+        self.data = {
+            "string": "string",
+            "integer": 1,
+            "true": True,
+            "false": False,
+            "date": dt.datetime(2020, 1, 13, 13, 13, 13),
+            "dict": {"key": "value", "one": 1},
+            "list": [1, 2, 3],
+            "data": b"binary-data",
+            "float": 0.01,
+            "nesteddict": {"d1": {"key": "value"}, "d2": {"key": "value2"}},
+            "nestedlist": [[1, 2, 3], [4, 5, 6]],
+            "dictoflists": {"one": [1, 2, 3], "two": [4, 5, 6]},
+            "listofdicts": [{"one": 1}, {"two": 2}],
+        }
         self.config.data = copy.deepcopy(self.data)
 
     def test_save_creates_file(self):
@@ -317,7 +318,7 @@ class TestSaveConfig(BaseTestCase):
         self.config.save()
         expected = self.data
         # read data from disk (raise FileNotFoundError if missing)
-        with open(self.config.path, 'rb') as f:
+        with open(self.config.path, "rb") as f:
             result = plistlib.load(f)
         self.assertDictEqual(expected, result)
 
@@ -329,12 +330,12 @@ class TestSaveConfig(BaseTestCase):
         # save data
         self.config.save()
         # misconfigure the data (None is not supported by plists)
-        self.config.data.update({'None': None})
+        self.config.data.update({"None": None})
         # attempt to save the misconfigured data (raises TypeError)
         with self.assertRaises(TypeError):
             self.config.save()
         # manually reload data from disk (raises expatError if corrupt)
-        with open(self.config.path, 'rb') as f:
+        with open(self.config.path, "rb") as f:
             result = plistlib.load(f)
         # verify nothing is wrong
         self.assertDictEqual(expected, result)
@@ -345,7 +346,7 @@ class TestSaveConfig(BaseTestCase):
         """
         self.assertFalse(self.config.path.exists())
         # misconfigure the data (None is not supported by plists)
-        self.config.data.update({'None': None})
+        self.config.data.update({"None": None})
         # attempt to save the misconfigured data (raises TypeError)
         with self.assertRaises(TypeError):
             self.config.save()
@@ -354,25 +355,25 @@ class TestSaveConfig(BaseTestCase):
 
 
 class TestConfigLoading(BaseTestCase):
-
     def setUp(self):
         super().setUp()
-        self.data = {'string': 'string',
-                     'integer': 1,
-                     'true': True,
-                     'false': False,
-                     'date': dt.datetime(2020, 1, 13, 13, 13, 13),
-                     'dict': {'key': 'value', 'one': 1},
-                     'list': [1, 2, 3],
-                     'data': b'binary-data',
-                     'float': 0.01,
-                     'nesteddict': {'d1': {'key': 'value'},
-                                    'd2': {'key': 'value2'}},
-                     'nestedlist': [[1, 2, 3], [4, 5, 6]],
-                     'dictoflists': {'one': [1, 2, 3], 'two': [4, 5, 6]},
-                     'listofdicts': [{'one': 1}, {'two': 2}]}
+        self.data = {
+            "string": "string",
+            "integer": 1,
+            "true": True,
+            "false": False,
+            "date": dt.datetime(2020, 1, 13, 13, 13, 13),
+            "dict": {"key": "value", "one": 1},
+            "list": [1, 2, 3],
+            "data": b"binary-data",
+            "float": 0.01,
+            "nesteddict": {"d1": {"key": "value"}, "d2": {"key": "value2"}},
+            "nestedlist": [[1, 2, 3], [4, 5, 6]],
+            "dictoflists": {"one": [1, 2, 3], "two": [4, 5, 6]},
+            "listofdicts": [{"one": 1}, {"two": 2}],
+        }
         # manually create file before each test
-        with open(self.config.path, 'wb') as f:
+        with open(self.config.path, "wb") as f:
             plistlib.dump(self.data, f)
 
     def tearDown(self):
@@ -401,10 +402,10 @@ class TestConfigLoading(BaseTestCase):
         """
         Test CorruptedConfigError raised when loading a corrupted config
         """
-        self.data.update({'None': None})
+        self.data.update({"None": None})
         # intentionally corrupt the file
         with self.assertRaises(TypeError):
-            with open(self.config.path, 'wb') as f:
+            with open(self.config.path, "wb") as f:
                 plistlib.dump(self.data, f)
         # verify
         with self.assertRaises(config.CorruptedConfigError):
@@ -421,66 +422,62 @@ class TestConfigLoading(BaseTestCase):
 
 
 class SecureConfigTestCase(ConfigTestCase):
-
     def setUp(self):
-        self.path = TMPDIR / 'jamf.config.secure.test.plist'
+        self.path = TMPDIR / "jamf.config.secure.test.plist"
         self.config = config.SecureConfig(path=self.path)
         self.transpose = config.transposition(config.MAGIC)
 
     def test_credentials_attribute(self):
-        self.assertTrue(hasattr(self.config, 'credentials'))
+        self.assertTrue(hasattr(self.config, "credentials"))
 
     def test_something(self):
-        expected = ('username', 'password')
+        expected = ("username", "password")
         if self.path.exists():
             self.path.unlink()
-        self.config.credentials('test', expected)
-        result = self.config.credentials('test')
+        self.config.credentials("test", expected)
+        result = self.config.credentials("test")
         self.assertEqual(expected, result)
 
 
 class TestSaveSecureConfig(TestSaveConfig):
-
     def setUp(self):
-        self.path = TMPDIR / 'jamf.config.secure.test.plist'
+        self.path = TMPDIR / "jamf.config.secure.test.plist"
         self.config = config.SecureConfig(path=self.path)
         super().setUp()
 
 
 class TestSecureConfigLoading(TestConfigLoading):
-
     def setUp(self):
-        self.path = TMPDIR / 'jamf.config.secure.test.plist'
+        self.path = TMPDIR / "jamf.config.secure.test.plist"
         self.config = config.SecureConfig(path=self.path)
         super().setUp()
 
 
 class CredentialsTest(unittest.TestCase):
-
     def setUp(self):
-        self.key = 'secret'
+        self.key = "secret"
         self.callback = config.transposition(self.key)
         self.credentials = config.Credentials({}, callback=self.callback)
 
     def test_retrieve_missing(self):
         with self.assertRaises(KeyError):
-            self.credentials.retrieve('missing')
+            self.credentials.retrieve("missing")
 
     def test_register_and_retrieve(self):
-        expected = 'value'
-        self.credentials.register('key', expected)
+        expected = "value"
+        self.credentials.register("key", expected)
         # print(self.credentials.data)
         # bplist = self.callback(self.credentials.data['key'])
         # print(plistlib.loads(bplist))
-        result = self.credentials.retrieve('key')
+        result = self.credentials.retrieve("key")
         self.assertEqual(expected, result)
 
     def test_register_None(self):
         # with self.assertRaises(ValueError):
         #     self.credentials.register('key', None)
         expected = None
-        self.credentials.register('key', expected)
-        result = self.credentials.retrieve('key')
+        self.credentials.register("key", expected)
+        result = self.credentials.retrieve("key")
         # print(self.credentials.data)
         # bplist = self.callback(self.credentials.data['key'])
         # print(bplist)
@@ -488,27 +485,26 @@ class CredentialsTest(unittest.TestCase):
         self.assertEqual(expected, result)
 
     def test_register_Credentials(self):
-        c = config.Credentials({'test': 'value'}, callback=self.callback)
+        c = config.Credentials({"test": "value"}, callback=self.callback)
         expected = c.data
-        self.credentials.register('key', c)
-        result = self.credentials.retrieve('key')
+        self.credentials.register("key", c)
+        result = self.credentials.retrieve("key")
         # print(result)
         self.assertEqual(expected, result)
 
     def test_something(self):
-        c = config.Credentials({'test': 'value'}, callback=self.callback)
+        c = config.Credentials({"test": "value"}, callback=self.callback)
         expected = c.data
-        self.credentials.register('key', c)
-        result = self.credentials.retrieve('key')
+        self.credentials.register("key", c)
+        result = self.credentials.retrieve("key")
         # print(result)
         self.assertEqual(expected, result)
 
 
 class TranspositionTest(unittest.TestCase):
-
     def setUp(self):
-        self.key = 'test'
-        self.secret = 'secret information'
+        self.key = "test"
+        self.secret = "secret information"
 
     def assertMirroredTransposition(self, func, secret):
         """
@@ -523,13 +519,14 @@ class TranspositionTest(unittest.TestCase):
         """
         assert the same func can be used to both encrypt and decrypt the secret
         """
-        expected = (bytes(secret, encoding='utf-8')
-                    if isinstance(secret, str) else secret)
+        expected = (
+            bytes(secret, encoding="utf-8") if isinstance(secret, str) else secret
+        )
         # encrypt the secret
         encrypted = func(secret)
         # verify the encrypted secret != original secret
         self.assertNotEqual(encrypted, expected)
-        e = 'transposition returned {0!r}: bytes expected'
+        e = "transposition returned {0!r}: bytes expected"
         self.assertIsInstance(encrypted, bytes, msg=e.format(encrypted))
         # decrypt the encrypted secret using the same function
         result = func(encrypted)
@@ -541,15 +538,15 @@ class TranspositionTest(unittest.TestCase):
         """
         test transposition
         """
-        transpose = config.transposition(b'test')
-        self.assertEqual(transpose(b'test'), b'\x00\x00\x00\x00')
+        transpose = config.transposition(b"test")
+        self.assertEqual(transpose(b"test"), b"\x00\x00\x00\x00")
 
     def test_reverse_transposition(self):
         """
         test reverse transposition
         """
-        transpose = config.transposition(b'test')
-        self.assertEqual(transpose(b'\x00\x00\x00\x00'), b'test')
+        transpose = config.transposition(b"test")
+        self.assertEqual(transpose(b"\x00\x00\x00\x00"), b"test")
 
     def test_tuple_key(self):
         """
@@ -579,7 +576,7 @@ class TranspositionTest(unittest.TestCase):
         """
         test key as bytes
         """
-        key = bytes(self.key, encoding='utf-8')
+        key = bytes(self.key, encoding="utf-8")
         func = config.transposition(key)
         self.assertEncryptedTransposition(func, self.secret)
 
@@ -588,14 +585,14 @@ class TranspositionTest(unittest.TestCase):
         test iterable of different types raises ValueError
         """
         with self.assertRaises(ValueError):
-            f = config.transposition((7, 't'))
+            f = config.transposition((7, "t"))
 
     def test_default_transposition(self):
         key = self.key
         self.assertMirroredTransposition(lambda x: x, self.secret)
 
 
-if __name__ == '__main__':
-    fmt = '%(asctime)s: %(levelname)8s: %(name)s - %(funcName)s(): %(message)s'
+if __name__ == "__main__":
+    fmt = "%(asctime)s: %(levelname)8s: %(name)s - %(funcName)s(): %(message)s"
     logging.basicConfig(level=logging.FATAL, format=fmt)
     unittest.main(verbosity=1)

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -4,10 +4,10 @@
 Unittests for jamf.package
 """
 
-__author__ = 'Sam Forester'
-__email__ = 'sam.forester@utah.edu'
-__copyright__ = 'Copyright (c) 2020 University of Utah, Marriott Library'
-__license__ = 'MIT'
+__author__ = "Sam Forester"
+__email__ = "sam.forester@utah.edu"
+__copyright__ = "Copyright (c) 2020 University of Utah, Marriott Library"
+__license__ = "MIT"
 __version__ = "1.0.1"
 
 # import os
@@ -22,8 +22,9 @@ from jamf import category
 
 # location for temporary files created with tests
 LOCATION = pathlib.Path(__file__).parent
-TMPDIR = LOCATION / 'tmp' / 'package'
-DATA = LOCATION / 'data' / 'package'
+TMPDIR = LOCATION / "tmp" / "package"
+DATA = LOCATION / "data" / "package"
+
 
 def setUpModule():
     """
@@ -32,7 +33,7 @@ def setUpModule():
     """
     # OPTIONAL
     TMPDIR.mkdir(mode=0o755, parents=True, exist_ok=True)
-    package.TMPDIR = TMPDIR / 'edu.utah.mlib.package.tests'
+    package.TMPDIR = TMPDIR / "edu.utah.mlib.package.tests"
 
 
 def tearDownModule():
@@ -44,7 +45,6 @@ def tearDownModule():
 
 
 class BaseTestCase(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls):
         pass
@@ -70,7 +70,7 @@ class TestPackageInit(BaseTestCase):
         """
         test FileNotFoundError is raised when given a bad path
         """
-        path = pathlib.Path('/does/not/exist')
+        path = pathlib.Path("/does/not/exist")
         if not path.exists():
             with self.assertRaises(FileNotFoundError):
                 package.Package(path)
@@ -79,16 +79,15 @@ class TestPackageInit(BaseTestCase):
         """
         test initialization succeeds
         """
-        path = DATA / 'pkgs' / 'edu.utah.mlib.package.test.pkg'
+        path = DATA / "pkgs" / "edu.utah.mlib.package.test.pkg"
         if path.exists():
             pkg = package.Package(path)
 
 
 class PackageTests(BaseTestCase):
-
     def setUp(self):
         super().setUp()
-        self.path = DATA / 'pkgs' / 'edu.utah.mlib.package.test.pkg'
+        self.path = DATA / "pkgs" / "edu.utah.mlib.package.test.pkg"
         self.pkg = package.Package(self.path)
 
     def test_sha512_checksum(self):
@@ -96,9 +95,11 @@ class PackageTests(BaseTestCase):
         test package sha512 checksum hexdigest
         """
         # `openssl sha512 /path/to/edu.utah.mlib.package.test.pkg`
-        expected = ('137aa99516b7c9e4d9e8e11e7fffbeb706f380886ff'
-                    '390da0b786053993903acc1190e3c27c1cde054f351'
-                    '5369e449f33be15c287aeba116d2e9f1a8dc2f5ff9')
+        expected = (
+            "137aa99516b7c9e4d9e8e11e7fffbeb706f380886ff"
+            "390da0b786053993903acc1190e3c27c1cde054f351"
+            "5369e449f33be15c287aeba116d2e9f1a8dc2f5ff9"
+        )
         result = self.pkg.sha512
         self.assertEqual(expected, result)
 
@@ -107,7 +108,7 @@ class PackageTests(BaseTestCase):
         test package md5 checksum hexdigest
         """
         # `openssl md5 /path/to/edu.utah.mlib.package.test.pkg`
-        expected = 'a37ae984343b3bbcedb7316e0f3cb349'
+        expected = "a37ae984343b3bbcedb7316e0f3cb349"
         result = self.pkg.md5
         self.assertEqual(expected, result)
 
@@ -131,7 +132,7 @@ class PackageTests(BaseTestCase):
         """
         test all package info keys are accounted for
         """
-        expected = ['contents', 'name', 'path', 'pkginfo']
+        expected = ["contents", "name", "path", "pkginfo"]
         result = sorted([str(x) for x in self.pkg.info.keys()])
         self.assertEqual(expected, result)
 
@@ -139,7 +140,7 @@ class PackageTests(BaseTestCase):
         """
         test package identifier
         """
-        expected = 'test.package'
+        expected = "test.package"
         result = self.pkg.identifier
         self.assertEqual(expected, result)
 
@@ -147,7 +148,7 @@ class PackageTests(BaseTestCase):
         """
         test package version
         """
-        expected = '1.0.1'
+        expected = "1.0.1"
         result = self.pkg.version
         self.assertEqual(expected, result)
 
@@ -155,7 +156,7 @@ class PackageTests(BaseTestCase):
         """
         test package install-location
         """
-        expected = '/Applications/Test Package'
+        expected = "/Applications/Test Package"
         result = self.pkg.location
         self.assertEqual(expected, result)
 
@@ -163,12 +164,16 @@ class PackageTests(BaseTestCase):
         """
         test package app
         """
-        expected = [{'CFBundleIdentifier': 'edu.utah.mlib.package.test',
-                     'CFBundleShortVersionString': '1.0.0',
-                     'CFBundleVersion': '100',
-                     'LSMinimumSystemVersion': '10.7.5',
-                     'name': 'package.app',
-                     'path': '/Applications/Test Package/package.app'}]
+        expected = [
+            {
+                "CFBundleIdentifier": "edu.utah.mlib.package.test",
+                "CFBundleShortVersionString": "1.0.0",
+                "CFBundleVersion": "100",
+                "LSMinimumSystemVersion": "10.7.5",
+                "name": "package.app",
+                "path": "/Applications/Test Package/package.app",
+            }
+        ]
         result = self.pkg.apps
         self.assertEqual(expected, result)
 
@@ -176,16 +181,18 @@ class PackageTests(BaseTestCase):
         """
         test package information
         """
-        expected = {'auth': 'root',
-                    'format-version': '2',
-                    'generator-version': 'InstallCmds-681 (18G2022)',
-                    'identifier': 'test.package',
-                    'install-location': '/Applications/Test Package',
-                    'overwrite-permissions': 'true',
-                    'postinstall-action': 'none',
-                    'relocatable': 'false',
-                    'version': '1.0.1'}
-        result = self.pkg.info['pkginfo']
+        expected = {
+            "auth": "root",
+            "format-version": "2",
+            "generator-version": "InstallCmds-681 (18G2022)",
+            "identifier": "test.package",
+            "install-location": "/Applications/Test Package",
+            "overwrite-permissions": "true",
+            "postinstall-action": "none",
+            "relocatable": "false",
+            "version": "1.0.1",
+        }
+        result = self.pkg.info["pkginfo"]
         self.assertEqual(expected, result)
 
     def test_size(self):
@@ -208,7 +215,7 @@ class PackageTests(BaseTestCase):
         test package expansion cleanup
         """
         path = self.pkg.expand()
-        del(self.pkg)
+        del self.pkg
         self.assertFalse(path.exists())
 
     def test_pkg_as_str(self):
@@ -219,6 +226,5 @@ class PackageTests(BaseTestCase):
         self.assertTrue(str(self.pkg) == expected)
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main(verbosity=1)

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-#pylint: disable=relative-beyond-top-level, missing-function-docstring
-#pylint: disable=missing-class-docstring, missing-module-docstring, invalid-name
+# pylint: disable=relative-beyond-top-level, missing-function-docstring
+# pylint: disable=missing-class-docstring, missing-module-docstring, invalid-name
 
 """
 test_records
@@ -14,13 +14,13 @@ from jamf import records
 
 LOGLEVEL = logging.DEBUG
 
+
 class Error(Exception):
     pass
 
 
 class MockAPIError(Error):
-
-    def __init__(self, method, message): #pylint: disable=super-init-not-called
+    def __init__(self, method, message):  # pylint: disable=super-init-not-called
         self.method = method
         self.message = message
 
@@ -36,6 +36,7 @@ class MockAPIError(Error):
 
 class Singleton(type):
     _instances = {}
+
     def __call__(cls, *a, **kw):
         if cls not in cls._instances:
             cls._instances[cls] = super(Singleton, cls).__call__(*a, **kw)
@@ -78,228 +79,225 @@ class MockAPI(metaclass=Singleton):
         :returns <dict|requests.Response>:
         """
         return {
-            'categories': Data.categories,
-            'categories/id/1': Data.category_by_id,
-            'categories/name/TEST': Data.category_by_name,
-            'computergroups': Data.computer_groups,
-            'computergroups/id/21': Data.computer_group_by_id,
-            'advancedcomputersearches': Data.computer_searches,
-            'advancedcomputersearches/id/1': Data.computer_search,
-            'advancedcomputer_searches/name/1': Data.computer_search,
+            "categories": Data.categories,
+            "categories/id/1": Data.category_by_id,
+            "categories/name/TEST": Data.category_by_name,
+            "computergroups": Data.computer_groups,
+            "computergroups/id/21": Data.computer_group_by_id,
+            "advancedcomputersearches": Data.computer_searches,
+            "advancedcomputersearches/id/1": Data.computer_search,
+            "advancedcomputer_searches/name/1": Data.computer_search,
         }[endpoint]
 
     def put(self, record, dta, raw=False):
-        r = record.split('/')
-        if len(r) != 3 or r[1] not in ('id', 'name'):
-            raise MockAPIError('put', f"bad request: {record}")
+        r = record.split("/")
+        if len(r) != 3 or r[1] not in ("id", "name"):
+            raise MockAPIError("put", f"bad request: {record}")
         try:
             val = int(record)
         except ValueError:
             if self.post_by_name:
-                return {'id': '1'}
+                return {"id": "1"}
             else:
-                raise MockAPIError(
-                    'put',
-                    f"Operation not supported {record}"
-                )
-        return {'id': '1'}
+                raise MockAPIError("put", f"Operation not supported {record}")
+        return {"id": "1"}
 
     def delete(self, record, raw=False):
-        r = record.split('/')
-        if len(r) != 3 or r[1] not in ('id', 'name'):
-            raise MockAPIError('delete', f"bad request: {record}")
+        r = record.split("/")
+        if len(r) != 3 or r[1] not in ("id", "name"):
+            raise MockAPIError("delete", f"bad request: {record}")
         try:
             val = int(r[2])
         except ValueError:
             if self.delete_by_name:
-                return {'id': '1'}
+                return {"id": "1"}
             else:
-                raise MockAPIError(
-                    'delete',
-                    f"Operation not supported {record}"
-                )
+                raise MockAPIError("delete", f"Operation not supported {record}")
         if val == 1:
-            return {'id': '1'}
+            return {"id": "1"}
         else:
-            raise MockAPIError('delete', 'No matching record: {record}')
+            raise MockAPIError("delete", "No matching record: {record}")
 
     def post(self, record, dta, raw=False):
-        r = record.split('/')
-        if r[1] not in ('id', 'name'):
-            raise MockAPIError('post', f"bad record: {record}")
+        r = record.split("/")
+        if r[1] not in ("id", "name"):
+            raise MockAPIError("post", f"bad record: {record}")
         try:
             val = int(r[2])
         except ValueError:
             if self.delete_by_name:
-                return {'id': '1'}
+                return {"id": "1"}
             else:
-                raise MockAPIError('post', "not passed id")
+                raise MockAPIError("post", "not passed id")
         if val != 1:
-            raise MockAPIError('post', "no record with that id")
-        return {'id': '1'}
+            raise MockAPIError("post", "no record with that id")
+        return {"id": "1"}
 
 
-class Data():
+class Data:
     """
     Class to hold the fake data for MockAPI to feed to test_records
     and test_records to compare what it gets.
     """
 
     computer_searches = {
-        'advanced_computer_searches': {
-            'advanced_computer_search': [
-                {'id': '1', 'name': 'Advanced'},
-                {'id': '2', 'name': 'fudge'},
-                {'id': '3', 'name': 'bizz'},
+        "advanced_computer_searches": {
+            "advanced_computer_search": [
+                {"id": "1", "name": "Advanced"},
+                {"id": "2", "name": "fudge"},
+                {"id": "3", "name": "bizz"},
             ],
-            'size': '1',
+            "size": "1",
         }
     }
 
-    computer_searches_expected = {'1': 'Advanced', '2': 'fudge', '3': 'bizz'}
+    computer_searches_expected = {"1": "Advanced", "2": "fudge", "3": "bizz"}
 
     computer_search = {
-        'advanced_computer_search': {
-            'id': '1',
-            'name': 'Advanced',
-            'view_as': 'Standard Web Page',
-            'sort_1': 'string',
-            'sort_2': 'string',
-            'sort_3': 'string',
-            'criteria': {
-                'size': '1',
-                'criterion':
-                {
-                    'name': 'Last Inventory Update',
-                    'priority': '0',
-                    'and_or': 'and',
-                    'search_type': 'more than x days ago',
-                    'value': '7',
-                    'opening_paren': 'false',
-                    'closing_paren': 'false'
-                }
+        "advanced_computer_search": {
+            "id": "1",
+            "name": "Advanced",
+            "view_as": "Standard Web Page",
+            "sort_1": "string",
+            "sort_2": "string",
+            "sort_3": "string",
+            "criteria": {
+                "size": "1",
+                "criterion": {
+                    "name": "Last Inventory Update",
+                    "priority": "0",
+                    "and_or": "and",
+                    "search_type": "more than x days ago",
+                    "value": "7",
+                    "opening_paren": "false",
+                    "closing_paren": "false",
+                },
             },
-            'display_fields': {'size': '1', 'display_field': {'name': 'IP Address'}},
-            'computers': {
-                'size': '2',
-                'computer':  [
+            "display_fields": {"size": "1", "display_field": {"name": "IP Address"}},
+            "computers": {
+                "size": "2",
+                "computer": [
                     {
-                        'id': '1',
-                        'name': 'Joes iMac',
-                        'udid': '55900BDC-347C-58B1-D249-F32244B11D30',
-                        'Computer_Name': 'Joes iMac'
+                        "id": "1",
+                        "name": "Joes iMac",
+                        "udid": "55900BDC-347C-58B1-D249-F32244B11D30",
+                        "Computer_Name": "Joes iMac",
                     },
                     {
-                        'id': '22',
-                        'name': 'Petes iMac',
-                        'udid': '55900BDC-347C-58B1-D249-F322C2B11D30',
-                        'Computer_Name': 'Petes iMac'
-                    }
-                ]
+                        "id": "22",
+                        "name": "Petes iMac",
+                        "udid": "55900BDC-347C-58B1-D249-F322C2B11D30",
+                        "Computer_Name": "Petes iMac",
+                    },
+                ],
             },
-            'site': {'id': '-1', 'name': 'None'}
+            "site": {"id": "-1", "name": "None"},
         }
     }
 
     computer_search_expected = {
-        'id': '1',
-        'name': 'Advanced',
-        'view_as': 'Standard Web Page',
-        'sort_1': 'string',
-        'sort_2': 'string',
-        'sort_3': 'string',
-        'criteria': {
-            'size': '1',
-            'criterion': {
-                'name': 'Last Inventory Update',
-                'priority': '0',
-                'and_or': 'and',
-                'search_type': 'more than x days ago',
-                'value': '7',
-                'opening_paren': 'false',
-                'closing_paren': 'false'
-            }
+        "id": "1",
+        "name": "Advanced",
+        "view_as": "Standard Web Page",
+        "sort_1": "string",
+        "sort_2": "string",
+        "sort_3": "string",
+        "criteria": {
+            "size": "1",
+            "criterion": {
+                "name": "Last Inventory Update",
+                "priority": "0",
+                "and_or": "and",
+                "search_type": "more than x days ago",
+                "value": "7",
+                "opening_paren": "false",
+                "closing_paren": "false",
+            },
         },
-        'display_fields': {'size': '1', 'display_field': {'name': 'IP Address'}},
-        'computers': {
-            'size': '2',
-            'computer':  [
+        "display_fields": {"size": "1", "display_field": {"name": "IP Address"}},
+        "computers": {
+            "size": "2",
+            "computer": [
                 {
-                    'id': '1',
-                    'name': 'Joes iMac',
-                    'udid': '55900BDC-347C-58B1-D249-F32244B11D30',
-                    'Computer_Name': 'Joes iMac'
+                    "id": "1",
+                    "name": "Joes iMac",
+                    "udid": "55900BDC-347C-58B1-D249-F32244B11D30",
+                    "Computer_Name": "Joes iMac",
                 },
                 {
-                    'id': '22',
-                    'name': 'Petes iMac',
-                    'udid': '55900BDC-347C-58B1-D249-F322C2B11D30',
-                    'Computer_Name': 'Petes iMac'
-                }
-            ]
+                    "id": "22",
+                    "name": "Petes iMac",
+                    "udid": "55900BDC-347C-58B1-D249-F322C2B11D30",
+                    "Computer_Name": "Petes iMac",
+                },
+            ],
         },
-        'site': {'id': '-1', 'name': 'None'}
+        "site": {"id": "-1", "name": "None"},
     }
 
     computer_groups = {
-        'computer_groups': {
-            'size': '25',
-            'computer_group': [
-                {'id': '80', 'name': 'All 10.13', 'is_smart': 'true'},
-                {'id': '79', 'name': 'All 10.14', 'is_smart': 'true'},
-                {'id': '77', 'name': 'All 10.15', 'is_smart': 'true'},
-                {'id': '1', 'name': 'All Managed Clients', 'is_smart': 'true'},
-                {'id': '58', 'name': 'Azure Token', 'is_smart': 'true'},
-                {'id': '63', 'name': 'BrokenAudit', 'is_smart': 'true'},
-                {'id': '62', 'name': 'Build Mini', 'is_smart': 'true'},
-                {'id': '36', 'name': 'Hardware - MacBook', 'is_smart': 'true'},
-                {'id': '35', 'name': 'Hardware - MacBook Air', 'is_smart': 'true'},
-                {'id': '34', 'name': 'Hardware - MacBook Pro', 'is_smart': 'true'},
-                {'id': '87', 'name': 'has Privileges.app', 'is_smart': 'true'},
-                {'id': '54', 'name': 'Installed - Adobe CC', 'is_smart': 'true'},
-                {'id': '74', 'name': 'Installed - BlueCoat4.10.3', 'is_smart': 'true'},
-                {'id': '46', 'name': 'Installed - Cisco Webex', 'is_smart': 'true'},
-                {'id': '44', 'name': 'Installed - Firefox', 'is_smart': 'true'},
-                {'id': '21', 'name': 'Installed - GarageBand', 'is_smart': 'true'},
-                {'id': '28', 'name': 'Installed - Google Chrome', 'is_smart': 'true'},
-                {'id': '30', 'name': 'Installed - Skim', 'is_smart': 'true'},
-                {'id': '45', 'name': 'Installed - Spotify', 'is_smart': 'true'},
-                {'id': '27', 'name': 'Installed - The Unarchiver', 'is_smart': 'true'},
-                {'id': '31', 'name': 'Installed - VLC', 'is_smart': 'true'},
-                {'id': '42', 'name': 'Compliance - Manual Exclusion', 'is_smart': 'false'},
-                {'id': '38', 'name': 'Test - Compliance Test', 'is_smart': 'false'},
-                {'id': '37', 'name': 'Test - WiFi Computers', 'is_smart': 'false'},
-                {'id': '8', 'name': 'Test Computers', 'is_smart': 'false'}
-            ]
+        "computer_groups": {
+            "size": "25",
+            "computer_group": [
+                {"id": "80", "name": "All 10.13", "is_smart": "true"},
+                {"id": "79", "name": "All 10.14", "is_smart": "true"},
+                {"id": "77", "name": "All 10.15", "is_smart": "true"},
+                {"id": "1", "name": "All Managed Clients", "is_smart": "true"},
+                {"id": "58", "name": "Azure Token", "is_smart": "true"},
+                {"id": "63", "name": "BrokenAudit", "is_smart": "true"},
+                {"id": "62", "name": "Build Mini", "is_smart": "true"},
+                {"id": "36", "name": "Hardware - MacBook", "is_smart": "true"},
+                {"id": "35", "name": "Hardware - MacBook Air", "is_smart": "true"},
+                {"id": "34", "name": "Hardware - MacBook Pro", "is_smart": "true"},
+                {"id": "87", "name": "has Privileges.app", "is_smart": "true"},
+                {"id": "54", "name": "Installed - Adobe CC", "is_smart": "true"},
+                {"id": "74", "name": "Installed - BlueCoat4.10.3", "is_smart": "true"},
+                {"id": "46", "name": "Installed - Cisco Webex", "is_smart": "true"},
+                {"id": "44", "name": "Installed - Firefox", "is_smart": "true"},
+                {"id": "21", "name": "Installed - GarageBand", "is_smart": "true"},
+                {"id": "28", "name": "Installed - Google Chrome", "is_smart": "true"},
+                {"id": "30", "name": "Installed - Skim", "is_smart": "true"},
+                {"id": "45", "name": "Installed - Spotify", "is_smart": "true"},
+                {"id": "27", "name": "Installed - The Unarchiver", "is_smart": "true"},
+                {"id": "31", "name": "Installed - VLC", "is_smart": "true"},
+                {
+                    "id": "42",
+                    "name": "Compliance - Manual Exclusion",
+                    "is_smart": "false",
+                },
+                {"id": "38", "name": "Test - Compliance Test", "is_smart": "false"},
+                {"id": "37", "name": "Test - WiFi Computers", "is_smart": "false"},
+                {"id": "8", "name": "Test Computers", "is_smart": "false"},
+            ],
         }
     }
 
     computer_groups_expected = {
-        '80': {'name': 'All 10.13', 'is_smart': 'true'},
-        '79': {'name': 'All 10.14', 'is_smart': 'true'},
-        '77': {'name': 'All 10.15', 'is_smart': 'true'},
-        '1': {'name': 'All Managed Clients', 'is_smart': 'true'},
-        '58': {'name': 'Azure Token', 'is_smart': 'true'},
-        '63': {'name': 'BrokenAudit', 'is_smart': 'true'},
-        '62': {'name': 'Build Mini', 'is_smart': 'true'},
-        '36': {'name': 'Hardware - MacBook', 'is_smart': 'true'},
-        '35': {'name': 'Hardware - MacBook Air', 'is_smart': 'true'},
-        '34': {'name': 'Hardware - MacBook Pro', 'is_smart': 'true'},
-        '87': {'name': 'has Privileges.app', 'is_smart': 'true'},
-        '54': {'name': 'Installed - Adobe CC', 'is_smart': 'true'},
-        '74': {'name': 'Installed - BlueCoat4.10.3', 'is_smart': 'true'},
-        '46': {'name': 'Installed - Cisco Webex', 'is_smart': 'true'},
-        '44': {'name': 'Installed - Firefox', 'is_smart': 'true'},
-        '21': {'name': 'Installed - GarageBand', 'is_smart': 'true'},
-        '28': {'name': 'Installed - Google Chrome', 'is_smart': 'true'},
-        '30': {'name': 'Installed - Skim', 'is_smart': 'true'},
-        '45': {'name': 'Installed - Spotify', 'is_smart': 'true'},
-        '27': {'name': 'Installed - The Unarchiver', 'is_smart': 'true'},
-        '31': {'name': 'Installed - VLC', 'is_smart': 'true'},
-        '42': {'name': 'Compliance - Manual Exclusion', 'is_smart': 'false'},
-        '38': {'name': 'Test - Compliance Test', 'is_smart': 'false'},
-        '37': {'name': 'Test - WiFi Computers', 'is_smart': 'false'},
-        '8': {'name': 'Test Computers', 'is_smart': 'false'}
+        "80": {"name": "All 10.13", "is_smart": "true"},
+        "79": {"name": "All 10.14", "is_smart": "true"},
+        "77": {"name": "All 10.15", "is_smart": "true"},
+        "1": {"name": "All Managed Clients", "is_smart": "true"},
+        "58": {"name": "Azure Token", "is_smart": "true"},
+        "63": {"name": "BrokenAudit", "is_smart": "true"},
+        "62": {"name": "Build Mini", "is_smart": "true"},
+        "36": {"name": "Hardware - MacBook", "is_smart": "true"},
+        "35": {"name": "Hardware - MacBook Air", "is_smart": "true"},
+        "34": {"name": "Hardware - MacBook Pro", "is_smart": "true"},
+        "87": {"name": "has Privileges.app", "is_smart": "true"},
+        "54": {"name": "Installed - Adobe CC", "is_smart": "true"},
+        "74": {"name": "Installed - BlueCoat4.10.3", "is_smart": "true"},
+        "46": {"name": "Installed - Cisco Webex", "is_smart": "true"},
+        "44": {"name": "Installed - Firefox", "is_smart": "true"},
+        "21": {"name": "Installed - GarageBand", "is_smart": "true"},
+        "28": {"name": "Installed - Google Chrome", "is_smart": "true"},
+        "30": {"name": "Installed - Skim", "is_smart": "true"},
+        "45": {"name": "Installed - Spotify", "is_smart": "true"},
+        "27": {"name": "Installed - The Unarchiver", "is_smart": "true"},
+        "31": {"name": "Installed - VLC", "is_smart": "true"},
+        "42": {"name": "Compliance - Manual Exclusion", "is_smart": "false"},
+        "38": {"name": "Test - Compliance Test", "is_smart": "false"},
+        "37": {"name": "Test - WiFi Computers", "is_smart": "false"},
+        "8": {"name": "Test Computers", "is_smart": "false"},
     }
 
     # note: the serial numbers and mac addresses are from a random
@@ -307,219 +305,207 @@ class Data():
     # length and format.
 
     computer_group_by_id = {
-        'computer_group': {
-            'id': '21',
-            'name': 'Installed - GarageBand',
-            'is_smart': 'true',
-            'site': {'id': '-1', 'name': 'None'},
-            'criteria': {
-                'size': '1',
-                'criterion': {
-                    'name': 'Application Title',
-                    'priority': '0',
-                    'and_or': 'and',
-                    'search_type': 'is',
-                    'value': 'Pages.app',
-                    'opening_paren': 'false',
-                    'closing_paren': 'false'
-                }
+        "computer_group": {
+            "id": "21",
+            "name": "Installed - GarageBand",
+            "is_smart": "true",
+            "site": {"id": "-1", "name": "None"},
+            "criteria": {
+                "size": "1",
+                "criterion": {
+                    "name": "Application Title",
+                    "priority": "0",
+                    "and_or": "and",
+                    "search_type": "is",
+                    "value": "Pages.app",
+                    "opening_paren": "false",
+                    "closing_paren": "false",
+                },
             },
-            'computers': {
-                'size': '4',
-                'computer': [
+            "computers": {
+                "size": "4",
+                "computer": [
                     {
-                        'id': '120',
-                        'name': 'C0265B896WZ9',
-                        'mac_address': '98:C0:48:D4:83:F7',
-                        'alt_mac_address': '83:23:23:C0:55:83',
-                        'serial_number': 'C0265B896WZ9'
+                        "id": "120",
+                        "name": "C0265B896WZ9",
+                        "mac_address": "98:C0:48:D4:83:F7",
+                        "alt_mac_address": "83:23:23:C0:55:83",
+                        "serial_number": "C0265B896WZ9",
                     },
                     {
-                        'id': '123',
-                        'name': 'C024B2BADVYD',
-                        'mac_address': '67:68:55:C0:67:67',
-                        'alt_mac_address': '83:83:98:23:F7:68',
-                        'serial_number': 'C024B2BADVYD'
+                        "id": "123",
+                        "name": "C024B2BADVYD",
+                        "mac_address": "67:68:55:C0:67:67",
+                        "alt_mac_address": "83:83:98:23:F7:68",
+                        "serial_number": "C024B2BADVYD",
                     },
                     {
-                        'id': '125',
-                        'name': 'C02DZVCT6U00',
-                        'mac_address': 'E7:55:83:E7:83:E7',
-                        'alt_mac_address': 'C7:B4:C7:67:F7:98',
-                        'serial_number': 'C02DZVCT6U00'
+                        "id": "125",
+                        "name": "C02DZVCT6U00",
+                        "mac_address": "E7:55:83:E7:83:E7",
+                        "alt_mac_address": "C7:B4:C7:67:F7:98",
+                        "serial_number": "C02DZVCT6U00",
                     },
                     {
-                        'id': '256',
-                        'name': 'C02DA56FXCAD',
-                        'mac_address': 'A3:A4:67:55:55:98',
-                        'alt_mac_address': 'A4:C0:00:A3:83:7A',
-                        'serial_number': 'C02Z18BVLVDC'
-                    }
-                ]
-            }
+                        "id": "256",
+                        "name": "C02DA56FXCAD",
+                        "mac_address": "A3:A4:67:55:55:98",
+                        "alt_mac_address": "A4:C0:00:A3:83:7A",
+                        "serial_number": "C02Z18BVLVDC",
+                    },
+                ],
+            },
         }
     }
 
     members_expected = {
-        '120': {
-            'name': 'C0265B896WZ9',
-            'mac_address': '98:C0:48:D4:83:F7',
-            'alt_mac_address': '83:23:23:C0:55:83',
-            'serial_number': 'C0265B896WZ9'
+        "120": {
+            "name": "C0265B896WZ9",
+            "mac_address": "98:C0:48:D4:83:F7",
+            "alt_mac_address": "83:23:23:C0:55:83",
+            "serial_number": "C0265B896WZ9",
         },
-        '123': {
-            'name': 'C024B2BADVYD',
-            'mac_address': '67:68:55:C0:67:67',
-            'alt_mac_address': '83:83:98:23:F7:68',
-            'serial_number': 'C024B2BADVYD'
+        "123": {
+            "name": "C024B2BADVYD",
+            "mac_address": "67:68:55:C0:67:67",
+            "alt_mac_address": "83:83:98:23:F7:68",
+            "serial_number": "C024B2BADVYD",
         },
-        '125': {
-            'name': 'C02DZVCT6U00',
-            'mac_address': 'E7:55:83:E7:83:E7',
-            'alt_mac_address': 'C7:B4:C7:67:F7:98',
-            'serial_number': 'C02DZVCT6U00'
+        "125": {
+            "name": "C02DZVCT6U00",
+            "mac_address": "E7:55:83:E7:83:E7",
+            "alt_mac_address": "C7:B4:C7:67:F7:98",
+            "serial_number": "C02DZVCT6U00",
         },
-        '256': {
-            'name': 'C02DA56FXCAD',
-            'mac_address': 'A3:A4:67:55:55:98',
-            'alt_mac_address': 'A4:C0:00:A3:83:7A',
-            'serial_number': 'C02Z18BVLVDC'
-        }
+        "256": {
+            "name": "C02DA56FXCAD",
+            "mac_address": "A3:A4:67:55:55:98",
+            "alt_mac_address": "A4:C0:00:A3:83:7A",
+            "serial_number": "C02Z18BVLVDC",
+        },
     }
 
     computer_group_by_id_expected = {
-        'id': '21',
-        'name': 'Installed - GarageBand',
-        'is_smart': 'true',
-        'site': {'id': '-1', 'name': 'None'},
-        'criteria': {
-            'size': '1',
-            'criterion': {
-                'name': 'Application Title',
-                'priority': '0',
-                'and_or': 'and',
-                'search_type': 'is',
-                'value': 'Pages.app',
-                'opening_paren': 'false',
-                'closing_paren': 'false'
-            }
+        "id": "21",
+        "name": "Installed - GarageBand",
+        "is_smart": "true",
+        "site": {"id": "-1", "name": "None"},
+        "criteria": {
+            "size": "1",
+            "criterion": {
+                "name": "Application Title",
+                "priority": "0",
+                "and_or": "and",
+                "search_type": "is",
+                "value": "Pages.app",
+                "opening_paren": "false",
+                "closing_paren": "false",
+            },
         },
-        'computers': {
-            'size': '4',
-            'computer': [
+        "computers": {
+            "size": "4",
+            "computer": [
                 {
-                    'id': '120',
-                    'name': 'C0265B896WZ9',
-                    'mac_address': '98:C0:48:D4:83:F7',
-                    'alt_mac_address': '83:23:23:C0:55:83',
-                    'serial_number': 'C0265B896WZ9'
+                    "id": "120",
+                    "name": "C0265B896WZ9",
+                    "mac_address": "98:C0:48:D4:83:F7",
+                    "alt_mac_address": "83:23:23:C0:55:83",
+                    "serial_number": "C0265B896WZ9",
                 },
                 {
-                    'id': '123',
-                    'name': 'C024B2BADVYD',
-                    'mac_address': '67:68:55:C0:67:67',
-                    'alt_mac_address': '83:83:98:23:F7:68',
-                    'serial_number': 'C024B2BADVYD'
+                    "id": "123",
+                    "name": "C024B2BADVYD",
+                    "mac_address": "67:68:55:C0:67:67",
+                    "alt_mac_address": "83:83:98:23:F7:68",
+                    "serial_number": "C024B2BADVYD",
                 },
                 {
-                    'id': '125',
-                    'name': 'C02DZVCT6U00',
-                    'mac_address': 'E7:55:83:E7:83:E7',
-                    'alt_mac_address': 'C7:B4:C7:67:F7:98',
-                    'serial_number': 'C02DZVCT6U00'},
+                    "id": "125",
+                    "name": "C02DZVCT6U00",
+                    "mac_address": "E7:55:83:E7:83:E7",
+                    "alt_mac_address": "C7:B4:C7:67:F7:98",
+                    "serial_number": "C02DZVCT6U00",
+                },
                 {
-                    'id': '256',
-                    'name': 'C02DA56FXCAD',
-                    'mac_address': 'A3:A4:67:55:55:98',
-                    'alt_mac_address': 'A4:C0:00:A3:83:7A',
-                    'serial_number': 'C02Z18BVLVDC'
-                }
-            ]
-        }
+                    "id": "256",
+                    "name": "C02DA56FXCAD",
+                    "mac_address": "A3:A4:67:55:55:98",
+                    "alt_mac_address": "A4:C0:00:A3:83:7A",
+                    "serial_number": "C02Z18BVLVDC",
+                },
+            ],
+        },
     }
 
     categories = {
-        'categories': {
-            'size': '16',
-            'category': [
-                {'id': '1', 'name': 'Applic'},
-                {'id': '2', 'name': 'CIS'},
-                {'id': '3', 'name': 'DEP-Onboarding'},
-                {'id': '15', 'name': 'Deprecated/Superceded'},
-                {'id': '16', 'name': 'Developer'},
-                {'id': '5', 'name': 'End User Experience'},
-                {'id': '6', 'name': 'First Aid'},
-                {'id': '11', 'name': 'How To Guides'},
-                {'id': '12', 'name': 'Intranet Shortcuts'},
-                {'id': '13', 'name': 'Maintenance'},
-                {'id': '7', 'name': 'Microsoft'},
-                {'id': '8', 'name': 'Networking'},
-                {'id': '17', 'name': 'OS Upgrades'},
-                {'id': '9', 'name': 'Security'},
-                {'id': '10', 'name': 'TEST'},
-                {'id': '14', 'name': 'User Guides'}
-            ]
+        "categories": {
+            "size": "16",
+            "category": [
+                {"id": "1", "name": "Applic"},
+                {"id": "2", "name": "CIS"},
+                {"id": "3", "name": "DEP-Onboarding"},
+                {"id": "15", "name": "Deprecated/Superceded"},
+                {"id": "16", "name": "Developer"},
+                {"id": "5", "name": "End User Experience"},
+                {"id": "6", "name": "First Aid"},
+                {"id": "11", "name": "How To Guides"},
+                {"id": "12", "name": "Intranet Shortcuts"},
+                {"id": "13", "name": "Maintenance"},
+                {"id": "7", "name": "Microsoft"},
+                {"id": "8", "name": "Networking"},
+                {"id": "17", "name": "OS Upgrades"},
+                {"id": "9", "name": "Security"},
+                {"id": "10", "name": "TEST"},
+                {"id": "14", "name": "User Guides"},
+            ],
         }
     }
 
     categories_expected = {
-        '1': 'Applic',
-        '2': 'CIS',
-        '3': 'DEP-Onboarding',
-        '15': 'Deprecated/Superceded',
-        '16': 'Developer',
-        '5': 'End User Experience',
-        '6': 'First Aid',
-        '11': 'How To Guides',
-        '12': 'Intranet Shortcuts',
-        '13': 'Maintenance',
-        '7': 'Microsoft',
-        '8': 'Networking',
-        '17': 'OS Upgrades',
-        '9': 'Security',
-        '10': 'TEST',
-        '14': 'User Guides'
+        "1": "Applic",
+        "2": "CIS",
+        "3": "DEP-Onboarding",
+        "15": "Deprecated/Superceded",
+        "16": "Developer",
+        "5": "End User Experience",
+        "6": "First Aid",
+        "11": "How To Guides",
+        "12": "Intranet Shortcuts",
+        "13": "Maintenance",
+        "7": "Microsoft",
+        "8": "Networking",
+        "17": "OS Upgrades",
+        "9": "Security",
+        "10": "TEST",
+        "14": "User Guides",
     }
 
-    category_by_id = {
-        'category': {'id': '1', 'name': 'Applications', 'priority': '2'}
-    }
+    category_by_id = {"category": {"id": "1", "name": "Applications", "priority": "2"}}
 
-    category_by_id_expected = {'id': '1', 'name': 'Applications', 'priority': '2'}
+    category_by_id_expected = {"id": "1", "name": "Applications", "priority": "2"}
 
-    category_by_name = {
-        'category': {'id': '10', 'name': 'TEST', 'priority': '9'}
-    }
+    category_by_name = {"category": {"id": "10", "name": "TEST", "priority": "9"}}
 
-    category_by_name_expected = {'id': '10', 'name': 'TEST', 'priority': '9'}
+    category_by_name_expected = {"id": "10", "name": "TEST", "priority": "9"}
 
     extension_attributes = {
-        'computer_extension_attributes': {
-            'size': '2',
-            'computer_extension_attribute': [
-                {
-                    'id': '1',
-                    'name': 'silliness',
-                    'enabled': 'true'
-                },
-                {
-                    'id': '11',
-                    'name': 'extended',
-                    'enabled': 'true'
-                }
-            ]
+        "computer_extension_attributes": {
+            "size": "2",
+            "computer_extension_attribute": [
+                {"id": "1", "name": "silliness", "enabled": "true"},
+                {"id": "11", "name": "extended", "enabled": "true"},
+            ],
         }
     }
 
 
 class TestListToDict(unittest.TestCase):
-
     def setUp(self):
         self.c = records.Categories()
         self.c.session = MockAPI()
 
     def test_list_to_dict(self):
-        lst = Data.categories['categories']['category']
+        lst = Data.categories["categories"]["category"]
         expected = Data.categories_expected
         result = self.c.list_to_dict(lst)
         self.assertEqual(expected, result)
@@ -527,7 +513,6 @@ class TestListToDict(unittest.TestCase):
 
 # Advanced Computer Searches
 class TestComputerSearches(unittest.TestCase):
-
     def setUp(self):
         self.c = records.ComputerSearches()
         self.c.session = MockAPI()
@@ -539,34 +524,34 @@ class TestComputerSearches(unittest.TestCase):
 
     def test_single_computer_search(self):
         expected = Data.computer_search_expected
-        result = self.c.get('1')
+        result = self.c.get("1")
         self.assertEqual(expected, result)
 
     def test_computer_search_post(self):
-        expected = {'id': '1'}
+        expected = {"id": "1"}
         dta = Data.computer_search_expected
-        result = self.c.post('1', dta)
+        result = self.c.post("1", dta)
         self.assertEqual(expected, result)
 
     def test_computer_search_put_by_name(self):
-        expected = {'id': '1'}
+        expected = {"id": "1"}
         record = Data.computer_search_expected
-        result = self.c.put('Advanced', record)
+        result = self.c.put("Advanced", record)
         self.assertEqual(expected, result)
 
     def test_computer_search_post_by_name(self):
-        expected = {'id': '1'}
+        expected = {"id": "1"}
         dta = Data.computer_search_expected
-        result = self.c.post('Advanced', dta)
+        result = self.c.post("Advanced", dta)
         self.assertEqual(expected, result)
 
     def test_computer_search_delete_by_name(self):
-        expected = {'id': '1'}
-        result = self.c.delete('Advanced')
+        expected = {"id": "1"}
+        result = self.c.delete("Advanced")
         self.assertEqual(expected, result)
 
-class TestCategories(unittest.TestCase):
 
+class TestCategories(unittest.TestCase):
     def setUp(self):
         self.c = records.Categories()
         self.c.session = MockAPI()
@@ -578,37 +563,36 @@ class TestCategories(unittest.TestCase):
 
     def test_single_category(self):
         expected = Data.category_by_id_expected
-        result = self.c.get('1')
+        result = self.c.get("1")
         self.assertEqual(expected, result)
 
     def test_category_put(self):
-        expected = {'id': '1'}
+        expected = {"id": "1"}
         record = Data.category_by_id_expected
-        result = self.c.put('1', record)
+        result = self.c.put("1", record)
         self.assertEqual(expected, result)
 
     def test_category_put_bad_id(self):
         record = Data.category_by_id_expected
-        self.assertRaises(MockAPIError, self.c.put, '3', record)
+        self.assertRaises(MockAPIError, self.c.put, "3", record)
 
     def test_category_put_name(self):
         record = Data.category_by_id_expected
-        self.assertRaises(records.JamfError, self.c.put, 'Gonzo', record)
+        self.assertRaises(records.JamfError, self.c.put, "Gonzo", record)
 
     def test_category_delete(self):
-        expected = {'id': '1'}
-        result = self.c.delete('1')
+        expected = {"id": "1"}
+        result = self.c.delete("1")
         self.assertEqual(expected, result)
 
     def test_category_delete_bad_id(self):
-        self.assertRaises(MockAPIError, self.c.delete, '3')
+        self.assertRaises(MockAPIError, self.c.delete, "3")
 
     def test_category_delete_name(self):
-        self.assertRaises(records.JamfError, self.c.delete, 'Ernie')
+        self.assertRaises(records.JamfError, self.c.delete, "Ernie")
 
 
 class TestComputerGroups(unittest.TestCase):
-
     def setUp(self):
         self.c = records.ComputerGroups()
         self.c.session = MockAPI()
@@ -620,7 +604,7 @@ class TestComputerGroups(unittest.TestCase):
 
     def test_single_computer_group(self):
         expected = sorted(Data.computer_group_by_id_expected)
-        result = sorted(self.c.get('21'))
+        result = sorted(self.c.get("21"))
         self.assertEqual(expected, result)
 
     def test_members(self):
@@ -628,5 +612,6 @@ class TestComputerGroups(unittest.TestCase):
         result = self.c.members(Data.computer_group_by_id_expected)
         self.assertEqual(expected, result)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main(verbosity=1)


### PR DESCRIPTION
For your consideration, this pull request applies [Python Black](https://black.readthedocs.io/en/stable/) formatting.

## Benefits

In the projects I've worked on, I've found that applying consistent autoformatting (whether Black or something similar like autopep8 or yapf) significantly streamlines contributions. Discussions about code style fade away, allowing contributors to focus on the function.

Also, Black's tendency to split long lines up slightly reduces the risk of merge conflicts if multiple elements of the same list/tuple/dict are edited by two different PRs.

Black sometimes also surfaces syntax bugs before commit, since the formatting won't run if the Python doesn't compile.

## Risks

Because this PR touches almost every Python file in the project, it's likely that it will conflict with changes on contributors' branches downstream. Any contributors will need to rebase their changes on the `main` branch (and possibly resolve conflicts manually) in order to continue. (At the moment, I don't see any non-merged branches here on GitHub, so it's probably a good time for a change like this.)

The most streamlined way to use Black is to configure your local development environment with it, so that every time you save, the formatting is applied. In my VSCode prefs, I have settings to facilitate this:

```
"python.formatting.provider": "black",
"python.formatting.blackPath": "/opt/homebrew/bin/black",
```

This optional streamlining creates a small additional setup burden for people who are regularly contributing, but shouldn't prevent those who wish to contribute more casually.

## Output

The changes in this PR were produced with `black .`, resulting in the output below. No changes to actual function were made.

```
% black .
reformatted jamf/convert.py
reformatted jamf/version.py
reformatted setup.py
reformatted jamf/config.py
reformatted jamf/setconfig.py
reformatted jamf/api.py
reformatted tests/api_mock_test.py
reformatted tests/convert_json_xml_test.py
reformatted tests/test_package.py
reformatted tests/test_config.py
reformatted jamf/admin.py
reformatted jamf/package.py
reformatted tests/test_records.py
reformatted jamf/records.py
All done! ✨ 🍰 ✨
14 files reformatted, 2 files left unchanged.
```

For more context, see [this portion of my 2019 PSU MacAdmins talk](https://youtu.be/mYKEM9Gplks?t=1335), which covers Black specifically.

Thanks for considering!