### PR TITLE
Add pre-commit configuration and corresponding GH Actions job

### DIFF
--- a/.github/workflows/pre-commit.sh
+++ b/.github/workflows/pre-commit.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+pip install pre-commit
+
+# Run pre-commit: if no errors, exit zero
+pre-commit run --all-files && exit 0
+
+# If we had errors but no changes to code, exit non-zero
+git diff --exit-code && exit 1
+
+# Commit and push changes made by pre-commit hooks
+git config user.name github-actions
+git config user.email github-actions@github.com
+git add -A
+git commit -anm "pre-commit auto fixes" || true
+git push || true
+
+# Run pre-commit again, passing through exit code
+pre-commit run --all-files

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,19 @@
+name: pre-commit
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
+      - name: Linting checks
+        run: .github/workflows/pre-commit.sh

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,6 @@
+[settings]
+multi_line_output=3
+include_trailing_comma=True
+force_grid_wrap=0
+use_parentheses=True
+line_length=88

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.2.0
+    hooks:
+      - id: check-added-large-files
+        args: [--maxkb=100]
+      - id: fix-byte-order-marker
+      - id: check-case-conflict
+      - id: check-docstring-first
+      - id: check-merge-conflict
+      - id: mixed-line-ending
+  - repo: https://github.com/python/black
+    rev: 22.3.0
+    hooks:
+      - id: black
+  - repo: https://github.com/pre-commit/mirrors-isort
+    rev: v5.10.1
+    hooks:
+      - id: isort

--- a/jamf/package.py
+++ b/jamf/package.py
@@ -10,7 +10,6 @@ __copyright__ = "Copyright (c) 2020 University of Utah, Marriott Library"
 __license__ = "MIT"
 __version__ = "1.1.3"
 
-# import re
 import os
 import shutil
 import hashlib

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -10,7 +10,6 @@ __copyright__ = "Copyright (c) 2020 University of Utah, Marriott Library"
 __license__ = "MIT"
 __version__ = "1.0.1"
 
-# import os
 import pprint
 import shutil
 import pathlib


### PR DESCRIPTION
This pull request creates a [pre-commit](https://pre-commit.com/) configuration and GitHub Actions job that runs it upon submitting PRs or pushing to `main`. The configuration includes two major formatting automations:

- **Python Black**: The project already uses Black manually; adding a pre-commit and CI config makes this formatting easier for contributors to adopt and ensures standard style for submitted pull requests
- **iSort**: Sorts Python imports in a consistent way, slightly reducing chances of merge conflict

The above two changes will result in a new commit being made to the codebase automatically once merged. The changes will be to style only, and should not affect function at all. [Here is a preview of that commit](https://github.com/homebysix/python-jamf/commit/b1a5593f13c9b7b1e32e14b9256a6c1b4bb0992d).

I've included a few other relatively minor checks. The codebase already complies with all of these, so no changes are needed for these.

- `check-added-large-files`: Helps prevent accidentally committing binary or image files to the repo by limiting new files to 100KB.
- `fix-byte-order-marker`: Ensures files have consistent byte order markers (e.g. after being edited by a contributor using Windows)
- `check-case-conflict`: Ensures no files are committed that would cause a conflict on case-insensitive file systems
- `check-docstring-first`: Ensures Python docstrings are in the proper place
- `check-merge-conflict`: Ensures no merge conflict markers are present in committed files
- `mixed-line-ending`: Forbids `CRLF` line endings

Once this is merged, it may be helpful to add a section to the jctl [Contribute wiki page](https://github.com/univ-of-utah-marriott-library-apple/jctl/wiki/Contribute#the-github-code-contribution-lifecycle), between the "Clone the Forked Repository" and "Create a Feature Branch" sections:

```
### Install and enable pre-commit

Pre-commit is a framework that automatically runs linting and consistency checks before changes
are committed to the repository locally. For contributors who will be working in Python code, we
recommend [installing pre-commit](https://pre-commit.com/#install) and running `pre-commit install`
in the repo to activate these checks.
```

(Note that even if contributors don't install pre-commit locally, GH Actions will run the checks upon submitting PRs and fix what it can.)

On the AutoPkg project, we made a [similar change](https://github.com/autopkg/autopkg/pull/793) recently, and it's worked well.